### PR TITLE
Remove limit of 255 for user_agent from Wurlf DB Api

### DIFF
--- a/Library/wurfl-dbapi-1.4.4.0/DatabaseConnectors/TeraWurflDatabase_MySQL5.php
+++ b/Library/wurfl-dbapi-1.4.4.0/DatabaseConnectors/TeraWurflDatabase_MySQL5.php
@@ -208,9 +208,6 @@ ORDER BY parent.`rt`",
 			foreach($devices as $device){
 				$this->dbcon->query("INSERT INTO `".TeraWurflConfig::$TABLE_PREFIX.'Index'."` (`deviceID`,`matcher`) VALUE (".$this->SQLPrep($device['id']).",".$this->SQLPrep($matcher).")");
 				// convert device root to tinyint format (0|1) for db
-				if(strlen($device['user_agent']) > 255){
-					$insert_errors[] = "Warning: user agent too long: \"".($device['id']).'"';
-				}
 				$insertcache[] = sprintf("(%s,%s,%s,%s,%s,%s)",
 					$this->SQLPrep($device['id']),
 					$this->SQLPrep($device['user_agent']),


### PR DESCRIPTION
Hello.

While installing this extension I found that the limit of 255 hardcoded in the wurfl API will make the import process fail with a newer version of the wurfl.xml file ( version 1.6.2 - 2015-06-22 16:05:41 ).
In the screenshot you see the error message that is displayed when this happens.
![2015-10-21_09-50-09](https://cloud.githubusercontent.com/assets/10879418/10631027/bb4dcad0-77e3-11e5-92e4-b451dd931e7b.png)

A quick fix for this is to simply remove or comment the line that adds this limitation. After this the import process will work properly and all necessary tables will be created.

In a newer version of the WURL DB Api this this limitation will not return an error ( https://github.com/fauvel/wurfl-dbapi/blob/master/DatabaseConnectors/TeraWurflDatabase_MySQL5.php#L212 ) .

Best Regards,
Dan
