### PR TITLE
style: apply PHP-CS-Fixer code style corrections

### DIFF
--- a/Classes/Context/Type/BrowserContext.php
+++ b/Classes/Context/Type/BrowserContext.php
@@ -52,18 +52,6 @@ class BrowserContext extends AbstractContext
     }
 
     /**
-     * Get the device detection service, with lazy initialization fallback.
-     */
-    protected function getDeviceDetectionService(): DeviceDetectionService
-    {
-        if ($this->deviceDetectionService === null) {
-            $this->deviceDetectionService = GeneralUtility::makeInstance(DeviceDetectionService::class);
-        }
-
-        return $this->deviceDetectionService;
-    }
-
-    /**
      * Check if the context matches the current request.
      *
      * Matches if the detected browser is in the configured list of browsers.
@@ -98,6 +86,18 @@ class BrowserContext extends AbstractContext
         $bMatch = $this->matchesBrowser($deviceInfo, $configuredBrowsers);
 
         return $this->storeInSession($this->invert($bMatch));
+    }
+
+    /**
+     * Get the device detection service, with lazy initialization fallback.
+     */
+    protected function getDeviceDetectionService(): DeviceDetectionService
+    {
+        if ($this->deviceDetectionService === null) {
+            $this->deviceDetectionService = GeneralUtility::makeInstance(DeviceDetectionService::class);
+        }
+
+        return $this->deviceDetectionService;
     }
 
     /**
@@ -138,7 +138,7 @@ class BrowserContext extends AbstractContext
         $browsers = explode(',', $browsersConfig);
         $browsers = array_map('trim', $browsers);
         $browsers = array_map('strtolower', $browsers);
-        $browsers = array_filter($browsers, static fn (string $browser): bool => $browser !== '');
+        $browsers = array_filter($browsers, static fn(string $browser): bool => $browser !== '');
 
         return array_values($browsers);
     }
@@ -158,6 +158,6 @@ class BrowserContext extends AbstractContext
 
         $detectedBrowser = strtolower($deviceInfo->browserName);
 
-        return in_array($detectedBrowser, $configuredBrowsers, true);
+        return \in_array($detectedBrowser, $configuredBrowsers, true);
     }
 }

--- a/Classes/Context/Type/DeviceContext.php
+++ b/Classes/Context/Type/DeviceContext.php
@@ -51,18 +51,6 @@ class DeviceContext extends AbstractContext
     }
 
     /**
-     * Get the device detection service, with lazy initialization fallback.
-     */
-    protected function getDeviceDetectionService(): DeviceDetectionService
-    {
-        if ($this->deviceDetectionService === null) {
-            $this->deviceDetectionService = GeneralUtility::makeInstance(DeviceDetectionService::class);
-        }
-
-        return $this->deviceDetectionService;
-    }
-
-    /**
      * Check if the context matches the current request.
      *
      * Matches if ANY of the configured device types matches the detected device.
@@ -108,6 +96,18 @@ class DeviceContext extends AbstractContext
         );
 
         return $this->storeInSession($this->invert($bMatch));
+    }
+
+    /**
+     * Get the device detection service, with lazy initialization fallback.
+     */
+    protected function getDeviceDetectionService(): DeviceDetectionService
+    {
+        if ($this->deviceDetectionService === null) {
+            $this->deviceDetectionService = GeneralUtility::makeInstance(DeviceDetectionService::class);
+        }
+
+        return $this->deviceDetectionService;
     }
 
     /**
@@ -172,10 +172,6 @@ class DeviceContext extends AbstractContext
         }
 
         // Check bot
-        if ($matchBot && $deviceInfo->isBot) {
-            return true;
-        }
-
-        return false;
+        return $matchBot && $deviceInfo->isBot;
     }
 }

--- a/Classes/Dto/DeviceInfo.php
+++ b/Classes/Dto/DeviceInfo.php
@@ -72,8 +72,7 @@ final readonly class DeviceInfo
          * Device model name (e.g., "iPhone 15", "Galaxy S24", "Pixel 8").
          */
         public ?string $deviceModel = null,
-    ) {
-    }
+    ) {}
 
     /**
      * Check if the device is a phone (mobile but not tablet).

--- a/Classes/Service/DeviceDetectionService.php
+++ b/Classes/Service/DeviceDetectionService.php
@@ -37,8 +37,7 @@ final class DeviceDetectionService
 
     public function __construct(
         private readonly DeviceDetector $deviceDetector,
-    ) {
-    }
+    ) {}
 
     /**
      * Detect device information from the current TYPO3 request.
@@ -116,8 +115,8 @@ final class DeviceDetectionService
         $os = $this->deviceDetector->getOs();
 
         // Normalize client and os to arrays (DeviceDetector returns string on failure)
-        $clientArray = is_array($client) ? $client : null;
-        $osArray = is_array($os) ? $os : null;
+        $clientArray = \is_array($client) ? $client : null;
+        $osArray = \is_array($os) ? $os : null;
 
         return new DeviceInfo(
             isMobile: $this->deviceDetector->isMobile(),
@@ -147,7 +146,7 @@ final class DeviceDetectionService
 
         $value = $data[$key];
 
-        if (!is_string($value) || $value === '') {
+        if (!\is_string($value) || $value === '') {
             return null;
         }
 

--- a/Tests/Architecture/LayerTest.php
+++ b/Tests/Architecture/LayerTest.php
@@ -31,7 +31,7 @@ final class LayerTest
             ->classes(Selector::inNamespace('Netresearch\ContextsDevice\Context\Type'))
             ->shouldExtend()
             ->classes(
-                Selector::classname('Netresearch\Contexts\Context\AbstractContext')
+                Selector::classname('Netresearch\Contexts\Context\AbstractContext'),
             )
             ->because('All context types should extend AbstractContext from the contexts extension');
     }

--- a/Tests/Unit/Context/Type/BrowserContextTest.php
+++ b/Tests/Unit/Context/Type/BrowserContextTest.php
@@ -24,15 +24,86 @@ use Psr\Http\Message\ServerRequestInterface;
 final class BrowserContextTest extends TestCase
 {
     private const CHROME_DESKTOP_UA = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36';
+
     private const FIREFOX_DESKTOP_UA = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:121.0) Gecko/20100101 Firefox/121.0';
+
     private const SAFARI_IPHONE_UA = 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.2 Mobile/15E148 Safari/604.1';
+
     private const EDGE_DESKTOP_UA = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36 Edg/120.0.0.0';
+
     private const OPERA_DESKTOP_UA = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36 OPR/106.0.0.0';
+
     private const GOOGLEBOT_UA = 'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)';
 
     protected function tearDown(): void
     {
         unset($GLOBALS['TYPO3_REQUEST']);
+    }
+
+    /**
+     * @return iterable<string, array{string, string, bool}>
+     */
+    public static function browserMatchDataProvider(): iterable
+    {
+        // Chrome scenarios
+        yield 'Chrome matches Chrome' => [
+            self::CHROME_DESKTOP_UA,
+            'Chrome',
+            true,
+        ];
+        yield 'Chrome matches Chrome in list' => [
+            self::CHROME_DESKTOP_UA,
+            'Firefox, Chrome, Safari',
+            true,
+        ];
+        yield 'Chrome does not match Firefox' => [
+            self::CHROME_DESKTOP_UA,
+            'Firefox',
+            false,
+        ];
+
+        // Firefox scenarios
+        yield 'Firefox matches Firefox' => [
+            self::FIREFOX_DESKTOP_UA,
+            'Firefox',
+            true,
+        ];
+        yield 'Firefox matches Firefox in list' => [
+            self::FIREFOX_DESKTOP_UA,
+            'Chrome, Firefox, Safari',
+            true,
+        ];
+        yield 'Firefox does not match Chrome' => [
+            self::FIREFOX_DESKTOP_UA,
+            'Chrome',
+            false,
+        ];
+
+        // Safari scenarios (Mobile Safari)
+        yield 'Mobile Safari matches Safari' => [
+            self::SAFARI_IPHONE_UA,
+            'Safari, Mobile Safari',
+            true,
+        ];
+
+        // Edge scenarios
+        yield 'Edge matches Edge' => [
+            self::EDGE_DESKTOP_UA,
+            'Microsoft Edge',
+            true,
+        ];
+        yield 'Edge matches Edge in list' => [
+            self::EDGE_DESKTOP_UA,
+            'Chrome, Microsoft Edge, Firefox',
+            true,
+        ];
+
+        // Opera scenarios
+        yield 'Opera matches Opera' => [
+            self::OPERA_DESKTOP_UA,
+            'Opera',
+            true,
+        ];
     }
 
     #[Test]
@@ -215,72 +286,6 @@ final class BrowserContextTest extends TestCase
         self::assertSame($expectedMatch, $context->match());
     }
 
-    /**
-     * @return iterable<string, array{string, string, bool}>
-     */
-    public static function browserMatchDataProvider(): iterable
-    {
-        // Chrome scenarios
-        yield 'Chrome matches Chrome' => [
-            self::CHROME_DESKTOP_UA,
-            'Chrome',
-            true,
-        ];
-        yield 'Chrome matches Chrome in list' => [
-            self::CHROME_DESKTOP_UA,
-            'Firefox, Chrome, Safari',
-            true,
-        ];
-        yield 'Chrome does not match Firefox' => [
-            self::CHROME_DESKTOP_UA,
-            'Firefox',
-            false,
-        ];
-
-        // Firefox scenarios
-        yield 'Firefox matches Firefox' => [
-            self::FIREFOX_DESKTOP_UA,
-            'Firefox',
-            true,
-        ];
-        yield 'Firefox matches Firefox in list' => [
-            self::FIREFOX_DESKTOP_UA,
-            'Chrome, Firefox, Safari',
-            true,
-        ];
-        yield 'Firefox does not match Chrome' => [
-            self::FIREFOX_DESKTOP_UA,
-            'Chrome',
-            false,
-        ];
-
-        // Safari scenarios (Mobile Safari)
-        yield 'Mobile Safari matches Safari' => [
-            self::SAFARI_IPHONE_UA,
-            'Safari, Mobile Safari',
-            true,
-        ];
-
-        // Edge scenarios
-        yield 'Edge matches Edge' => [
-            self::EDGE_DESKTOP_UA,
-            'Microsoft Edge',
-            true,
-        ];
-        yield 'Edge matches Edge in list' => [
-            self::EDGE_DESKTOP_UA,
-            'Chrome, Microsoft Edge, Firefox',
-            true,
-        ];
-
-        // Opera scenarios
-        yield 'Opera matches Opera' => [
-            self::OPERA_DESKTOP_UA,
-            'Opera',
-            true,
-        ];
-    }
-
     #[Test]
     public function matchIgnoresEmptyEntriesInBrowserList(): void
     {
@@ -329,6 +334,7 @@ final class BrowserContextTest extends TestCase
             $invert,
         ) extends BrowserContext {
             private string $testBrowsers;
+
             private bool $testInvert;
 
             public function __construct(

--- a/Tests/Unit/Dto/DeviceInfoTest.php
+++ b/Tests/Unit/Dto/DeviceInfoTest.php
@@ -20,6 +20,18 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(DeviceInfo::class)]
 final class DeviceInfoTest extends TestCase
 {
+    /**
+     * @return iterable<string, array{bool, bool, bool, bool, bool}>
+     */
+    public static function deviceTypeDataProvider(): iterable
+    {
+        yield 'mobile phone' => [true, false, false, false, true];
+        yield 'tablet' => [true, true, false, false, false];
+        yield 'desktop' => [false, false, true, false, false];
+        yield 'bot' => [false, false, false, true, false];
+        yield 'mobile bot' => [true, false, false, true, true];
+    }
+
     #[Test]
     public function constructorSetsAllProperties(): void
     {
@@ -105,7 +117,7 @@ final class DeviceInfoTest extends TestCase
         bool $isTablet,
         bool $isDesktop,
         bool $isBot,
-        bool $expectedIsPhone
+        bool $expectedIsPhone,
     ): void {
         $deviceInfo = new DeviceInfo(
             isMobile: $isMobile,
@@ -115,18 +127,6 @@ final class DeviceInfoTest extends TestCase
         );
 
         self::assertSame($expectedIsPhone, $deviceInfo->isPhone());
-    }
-
-    /**
-     * @return iterable<string, array{bool, bool, bool, bool, bool}>
-     */
-    public static function deviceTypeDataProvider(): iterable
-    {
-        yield 'mobile phone' => [true, false, false, false, true];
-        yield 'tablet' => [true, true, false, false, false];
-        yield 'desktop' => [false, false, true, false, false];
-        yield 'bot' => [false, false, false, true, false];
-        yield 'mobile bot' => [true, false, false, true, true];
     }
 
     #[Test]

--- a/Tests/Unit/Service/DeviceDetectionServiceTest.php
+++ b/Tests/Unit/Service/DeviceDetectionServiceTest.php
@@ -24,10 +24,84 @@ use Psr\Http\Message\ServerRequestInterface;
 final class DeviceDetectionServiceTest extends TestCase
 {
     private const CHROME_DESKTOP_UA = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36';
+
     private const IPHONE_UA = 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.2 Mobile/15E148 Safari/604.1';
+
     private const IPAD_UA = 'Mozilla/5.0 (iPad; CPU OS 17_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.2 Mobile/15E148 Safari/604.1';
+
     private const GOOGLEBOT_UA = 'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)';
+
     private const ANDROID_UA = 'Mozilla/5.0 (Linux; Android 14; SM-S928B) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Mobile Safari/537.36';
+
+    /**
+     * @return iterable<string, array{string, bool, bool, bool, bool}>
+     */
+    public static function userAgentDataProvider(): iterable
+    {
+        yield 'Chrome on Windows' => [
+            'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+            false, // isMobile
+            false, // isTablet
+            true,  // isDesktop
+            false, // isBot
+        ];
+
+        yield 'Safari on macOS' => [
+            'Mozilla/5.0 (Macintosh; Intel Mac OS X 14_2) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.2 Safari/605.1.15',
+            false, // isMobile
+            false, // isTablet
+            true,  // isDesktop
+            false, // isBot
+        ];
+
+        yield 'Firefox on Linux' => [
+            'Mozilla/5.0 (X11; Linux x86_64; rv:120.0) Gecko/20100101 Firefox/120.0',
+            false, // isMobile
+            false, // isTablet
+            true,  // isDesktop
+            false, // isBot
+        ];
+
+        yield 'Chrome on Android phone' => [
+            'Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Mobile Safari/537.36',
+            true,  // isMobile
+            false, // isTablet
+            false, // isDesktop
+            false, // isBot
+        ];
+
+        yield 'Safari on iPhone' => [
+            'Mozilla/5.0 (iPhone; CPU iPhone OS 17_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.2 Mobile/15E148 Safari/604.1',
+            true,  // isMobile
+            false, // isTablet
+            false, // isDesktop
+            false, // isBot
+        ];
+
+        yield 'Safari on iPad' => [
+            'Mozilla/5.0 (iPad; CPU OS 17_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.2 Mobile/15E148 Safari/604.1',
+            true,  // isMobile
+            true,  // isTablet
+            false, // isDesktop
+            false, // isBot
+        ];
+
+        yield 'Googlebot' => [
+            'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)',
+            false, // isMobile
+            false, // isTablet
+            false, // isDesktop
+            true,  // isBot
+        ];
+
+        yield 'Bingbot' => [
+            'Mozilla/5.0 (compatible; bingbot/2.0; +http://www.bing.com/bingbot.htm)',
+            false, // isMobile
+            false, // isTablet
+            false, // isDesktop
+            true,  // isBot
+        ];
+    }
 
     #[Test]
     public function detectFromUserAgentReturnsDeviceInfoForDesktop(): void
@@ -232,7 +306,7 @@ final class DeviceDetectionServiceTest extends TestCase
         bool $expectedIsMobile,
         bool $expectedIsTablet,
         bool $expectedIsDesktop,
-        bool $expectedIsBot
+        bool $expectedIsBot,
     ): void {
         $deviceDetector = new DeviceDetector();
         $service = new DeviceDetectionService($deviceDetector);
@@ -244,76 +318,6 @@ final class DeviceDetectionServiceTest extends TestCase
         self::assertSame($expectedIsTablet, $result->isTablet, 'isTablet mismatch');
         self::assertSame($expectedIsDesktop, $result->isDesktop, 'isDesktop mismatch');
         self::assertSame($expectedIsBot, $result->isBot, 'isBot mismatch');
-    }
-
-    /**
-     * @return iterable<string, array{string, bool, bool, bool, bool}>
-     */
-    public static function userAgentDataProvider(): iterable
-    {
-        yield 'Chrome on Windows' => [
-            'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
-            false, // isMobile
-            false, // isTablet
-            true,  // isDesktop
-            false, // isBot
-        ];
-
-        yield 'Safari on macOS' => [
-            'Mozilla/5.0 (Macintosh; Intel Mac OS X 14_2) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.2 Safari/605.1.15',
-            false, // isMobile
-            false, // isTablet
-            true,  // isDesktop
-            false, // isBot
-        ];
-
-        yield 'Firefox on Linux' => [
-            'Mozilla/5.0 (X11; Linux x86_64; rv:120.0) Gecko/20100101 Firefox/120.0',
-            false, // isMobile
-            false, // isTablet
-            true,  // isDesktop
-            false, // isBot
-        ];
-
-        yield 'Chrome on Android phone' => [
-            'Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Mobile Safari/537.36',
-            true,  // isMobile
-            false, // isTablet
-            false, // isDesktop
-            false, // isBot
-        ];
-
-        yield 'Safari on iPhone' => [
-            'Mozilla/5.0 (iPhone; CPU iPhone OS 17_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.2 Mobile/15E148 Safari/604.1',
-            true,  // isMobile
-            false, // isTablet
-            false, // isDesktop
-            false, // isBot
-        ];
-
-        yield 'Safari on iPad' => [
-            'Mozilla/5.0 (iPad; CPU OS 17_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.2 Mobile/15E148 Safari/604.1',
-            true,  // isMobile
-            true,  // isTablet
-            false, // isDesktop
-            false, // isBot
-        ];
-
-        yield 'Googlebot' => [
-            'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)',
-            false, // isMobile
-            false, // isTablet
-            false, // isDesktop
-            true,  // isBot
-        ];
-
-        yield 'Bingbot' => [
-            'Mozilla/5.0 (compatible; bingbot/2.0; +http://www.bing.com/bingbot.htm)',
-            false, // isMobile
-            false, // isTablet
-            false, // isDesktop
-            true,  // isBot
-        ];
     }
 
     #[Test]


### PR DESCRIPTION
## Summary

- Fix PHP-CS-Fixer violations in 9 files (formatting, blank lines, spacing)
- CI lint jobs have been failing on `main` since these were introduced

## Files fixed

- `Classes/Service/DeviceDetectionService.php`
- `Classes/Context/Type/DeviceContext.php`
- `Classes/Context/Type/BrowserContext.php`
- `Classes/Dto/DeviceInfo.php`
- `Tests/Unit/Service/DeviceDetectionServiceTest.php`
- `Tests/Unit/Context/Type/BrowserContextTest.php`
- `Tests/Unit/Context/Type/DeviceContextTest.php`
- `Tests/Unit/Dto/DeviceInfoTest.php`
- `Tests/Architecture/LayerTest.php`

## Test plan

- [ ] Lint (PHP 8.3) passes
- [ ] Lint (PHP 8.4) passes
- [ ] No regressions in PHPStan or unit tests