### PR TITLE
chore: add SPDX copyright and license headers

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
 /**
  * PHP-CS-Fixer configuration for TYPO3 extension.
  *

--- a/Build/Scripts/router.php
+++ b/Build/Scripts/router.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
 /**
  * Router script for PHP built-in server to handle TYPO3 rewrites
  *

--- a/Classes/Context/Type/BrowserContext.php
+++ b/Classes/Context/Type/BrowserContext.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
 /**
  * This file is part of the package netresearch/contexts-wurfl.
  *

--- a/Classes/Context/Type/DeviceContext.php
+++ b/Classes/Context/Type/DeviceContext.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
 /**
  * This file is part of the package netresearch/contexts-wurfl.
  *

--- a/Classes/Dto/DeviceInfo.php
+++ b/Classes/Dto/DeviceInfo.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
 /**
  * This file is part of the package netresearch/contexts-wurfl.
  *

--- a/Classes/Service/DeviceDetectionService.php
+++ b/Classes/Service/DeviceDetectionService.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
 /**
  * This file is part of the package netresearch/contexts-wurfl.
  *

--- a/Configuration/Icons.php
+++ b/Configuration/Icons.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
 declare(strict_types=1);
 
 use TYPO3\CMS\Core\Imaging\IconProvider\SvgIconProvider;

--- a/Configuration/TCA/Overrides/tx_contexts_contexts.php
+++ b/Configuration/TCA/Overrides/tx_contexts_contexts.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
 /**
  * This file is part of the package netresearch/contexts-wurfl.
  *

--- a/Tests/Architecture/LayerTest.php
+++ b/Tests/Architecture/LayerTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
 /**
  * This file is part of the package netresearch/contexts-wurfl.
  *

--- a/Tests/Functional/Context/Type/BrowserContextTest.php
+++ b/Tests/Functional/Context/Type/BrowserContextTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
 /**
  * This file is part of the package netresearch/contexts-wurfl.
  *

--- a/Tests/Functional/Context/Type/DeviceContextTest.php
+++ b/Tests/Functional/Context/Type/DeviceContextTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
 /**
  * This file is part of the package netresearch/contexts-wurfl.
  *

--- a/Tests/Unit/Context/Type/BrowserContextTest.php
+++ b/Tests/Unit/Context/Type/BrowserContextTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
 /**
  * This file is part of the package netresearch/contexts-wurfl.
  *

--- a/Tests/Unit/Context/Type/DeviceContextTest.php
+++ b/Tests/Unit/Context/Type/DeviceContextTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
 /**
  * This file is part of the package netresearch/contexts-wurfl.
  *

--- a/Tests/Unit/Dto/DeviceInfoTest.php
+++ b/Tests/Unit/Dto/DeviceInfoTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
 /**
  * This file is part of the package netresearch/contexts-wurfl.
  *

--- a/Tests/Unit/Service/DeviceDetectionServiceTest.php
+++ b/Tests/Unit/Service/DeviceDetectionServiceTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
 /**
  * This file is part of the package netresearch/contexts-wurfl.
  *

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
 declare(strict_types=1);
 
 $EM_CONF[$_EXTKEY] = [

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
 declare(strict_types=1);
 
 defined('TYPO3') or die();


### PR DESCRIPTION
## Summary
- Add SPDX copyright and license headers to all 17 PHP source files
- Headers: `Copyright (c) 2025-2026 Netresearch DTT GmbH` + `SPDX-License-Identifier: AGPL-3.0-or-later`
- Supports OpenSSF Best Practices Gold badge criteria

## Test plan
- [ ] CI passes (headers are comment-only, no functional changes)