### PR TITLE
ci: enable Codecov coverage reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,3 +18,6 @@ jobs:
       db-image: 'mysql:8.4'
       run-rector: false
       remove-dev-deps: '[{"dep":"saschaegerer/phpstan-typo3","only-for":"^13"}]'
+      upload-coverage: true
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Summary
- Enable Codecov coverage uploads in CI workflow
- Add `upload-coverage: true` to shared workflow call
- Pass `CODECOV_TOKEN` secret for authenticated uploads

This enables statement coverage tracking via Codecov, required for OpenSSF Best Practices Silver badge (`test_statement_coverage80` criterion).

## Test plan
- [ ] CI runs successfully with coverage enabled
- [ ] Coverage report appears on Codecov
- [ ] Statement coverage >= 80% for Silver badge