### PR TITLE
fix: add merge_group trigger and gitleaks allowlist

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ name: CI
 on:
   push:
   pull_request:
+  merge_group:
   schedule:
     - cron: '0 6 * * 1'
 

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,6 @@
+# Gitleaks configuration — allowlist for false positives
+[allowlist]
+  paths = [
+    '.Build/vendor/',
+  ]
+


### PR DESCRIPTION
## Summary
- Add `merge_group:` event trigger to CI workflow so merge queue checks run properly
- Without this trigger, PRs get stuck in the merge queue waiting for checks that never start
- Add `.gitleaks.toml` allowlist for false positives in committed `.Build/vendor/` directory (firebase/php-jwt `private-key` and symfony/mime `generic-api-key`)

## Test plan
- [ ] CI checks pass on this PR
- [ ] Gitleaks no longer reports false positives from vendor directory
- [ ] Merge queue properly triggers checks after merge