### PR TITLE
fix(router): canonicalise via realpath, contain in .Build/Web

### DIFF
--- a/Build/Scripts/router.php
+++ b/Build/Scripts/router.php
@@ -15,25 +15,38 @@
  *   php -S 0.0.0.0:8080 -t .Build/Web Build/Scripts/router.php
  *
  * The router:
- * 1. Serves static files (CSS, JS, images, etc.) directly
- * 2. Routes all other requests through TYPO3's index.php
- * 3. Preserves request URI for proper routing
+ * 1. Serves static files (CSS, JS, images, etc.) directly, but only if the
+ *    canonicalised path stays inside the .Build/Web web root (closes #30).
+ * 2. Routes all other requests through TYPO3's index.php.
+ *
+ * Even though this script is dev-only and never deployed, the realpath()
+ * containment check makes the file-serving branch immune to traversal
+ * payloads (`/../../etc/passwd`, double-encoded `%2e%2e`, symlinks, etc.).
  *
  * @package Netresearch\ContextsWurfl
  */
 
 declare(strict_types=1);
 
-$path = parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH);
-$file = __DIR__ . '/../../.Build/Web' . $path;
+$webRoot = realpath(__DIR__ . '/../../.Build/Web');
+$path    = parse_url((string) ($_SERVER['REQUEST_URI'] ?? ''), PHP_URL_PATH);
 
-// Serve static files directly.
-// nosemgrep: php.lang.security.injection.tainted-filename.tainted-filename -- dev-only PHP built-in server router for local E2E tests; never deployed. Tracked in #30 for proper realpath()-based hardening.
-if (is_file($file)) {
-    return false;
+// Serve a file directly only if the resolved path is a real file *inside*
+// the web root. realpath() resolves `.`, `..`, and symlinks before we
+// compare, so a request like `/../../etc/passwd` cannot escape the
+// allowed root no matter how it's encoded.
+if (is_string($path) && $webRoot !== false) {
+    $candidate = realpath($webRoot . $path);
+
+    if ($candidate !== false
+        && is_file($candidate)
+        && str_starts_with($candidate . DIRECTORY_SEPARATOR, $webRoot . DIRECTORY_SEPARATOR)
+    ) {
+        return false;
+    }
 }
 
 // Route everything else through TYPO3 index.php
-$_SERVER['SCRIPT_NAME'] = '/index.php';
+$_SERVER['SCRIPT_NAME']     = '/index.php';
 $_SERVER['SCRIPT_FILENAME'] = __DIR__ . '/../../.Build/Web/index.php';
 require __DIR__ . '/../../.Build/Web/index.php';

--- a/Build/Scripts/router.php
+++ b/Build/Scripts/router.php
@@ -28,15 +28,18 @@
 
 declare(strict_types=1);
 
-$webRoot = realpath(__DIR__ . '/../../.Build/Web');
-$path    = parse_url((string) ($_SERVER['REQUEST_URI'] ?? ''), PHP_URL_PATH);
+$webRoot   = realpath(__DIR__ . '/../../.Build/Web');
+$indexFile = __DIR__ . '/../../.Build/Web/index.php';
+$path      = parse_url((string) ($_SERVER['REQUEST_URI'] ?? ''), PHP_URL_PATH);
 
 // Serve a file directly only if the resolved path is a real file *inside*
 // the web root. realpath() resolves `.`, `..`, and symlinks before we
 // compare, so a request like `/../../etc/passwd` cannot escape the
-// allowed root no matter how it's encoded.
+// allowed root no matter how it's encoded. rawurldecode() unescapes
+// percent-encoded characters (e.g. `my%20file.css` → `my file.css`)
+// so the filesystem lookup matches the actual on-disk name.
 if (is_string($path) && $webRoot !== false) {
-    $candidate = realpath($webRoot . $path);
+    $candidate = realpath($webRoot . rawurldecode($path));
 
     if ($candidate !== false
         && is_file($candidate)
@@ -48,5 +51,5 @@ if (is_string($path) && $webRoot !== false) {
 
 // Route everything else through TYPO3 index.php
 $_SERVER['SCRIPT_NAME']     = '/index.php';
-$_SERVER['SCRIPT_FILENAME'] = __DIR__ . '/../../.Build/Web/index.php';
-require __DIR__ . '/../../.Build/Web/index.php';
+$_SERVER['SCRIPT_FILENAME'] = $indexFile;
+require $indexFile;


### PR DESCRIPTION
Closes #30.

## Why

`Build/Scripts/router.php` is the dev-only PHP built-in-server router used during local E2E tests. The previous implementation served any path that `is_file()` resolved, with no canonicalisation or containment:

```php
$path = parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH);
$file = __DIR__ . '/../../.Build/Web' . $path;
if (is_file($file)) { return false; }
```

Even on a dev-only script that's never deployed, a traversal payload like `/../../etc/passwd` (or a symlink, or double-encoded `%2e%2e`) would resolve to a real file and be handed back to the built-in server. Opengrep `tainted-filename` flagged this; #29 added an inline `nosemgrep` suppression with a tracking link to this issue.

## What

Realpath-and-contain:

```php
$webRoot   = realpath(__DIR__ . '/../../.Build/Web');
$candidate = realpath($webRoot . $path);
if ($candidate !== false
    && is_file($candidate)
    && str_starts_with($candidate . DIRECTORY_SEPARATOR, $webRoot . DIRECTORY_SEPARATOR)) {
    return false;
}
```

`realpath()` resolves `.`, `..`, and symlinks before the prefix check, so the file-serving branch is immune regardless of encoding. Failed canonicalisation or out-of-root resolution falls through to the TYPO3 entry point as before.

The `nosemgrep` suppression line is removed — the rule is enforced at full strength so any future regression flags.

## Verification

`php -l Build/Scripts/router.php` clean. Behaviour for legitimate static assets (`/typo3conf/...`, `/fileadmin/...`) unchanged — they all resolve inside `.Build/Web`.