### PR TITLE
feat(rector): enable rector with the shared org config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,6 @@ jobs:
       upload-coverage: true
       functional-test-db: 'mysql'
       db-image: 'mysql:8.4'
-      remove-dev-deps: '[{"dep":"saschaegerer/phpstan-typo3","only-for":"^13"}]'
+      remove-dev-deps: '[{"dep":"saschaegerer/phpstan-typo3","only-for":"^13"},{"dep":"netresearch/typo3-ci-workflows","only-for":"^13.4|^14.3"}]'
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/Build/rector.php
+++ b/Build/rector.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+
+$configure = require_once __DIR__ . '/../.Build/vendor/netresearch/typo3-ci-workflows/config/rector/rector.php';
+
+return static function (RectorConfig $rectorConfig) use ($configure): void {
+    // Shared org base config: code-quality sets, rule skips, importNames,
+    // and the package's ergebnis-free phpstan-rector.neon.
+    $configure($rectorConfig, __DIR__ . '/..');
+
+    // paths() REPLACES the shared list, so restate it and add Tests/ — the
+    // test suite is analysed by PHPStan and CGL here too.
+    $rectorConfig->paths([
+        __DIR__ . '/../Classes',
+        __DIR__ . '/../Configuration',
+        __DIR__ . '/../Resources',
+        __DIR__ . '/../Tests',
+        __DIR__ . '/../ext_localconf.php',
+    ]);
+};

--- a/Classes/AGENTS.md
+++ b/Classes/AGENTS.md
@@ -9,7 +9,8 @@ PHP source code for the Contexts Device Detection extension.
 ```
 Classes/
 ├── Context/           # Device detection context types
-│   └── Type/          # DeviceContext implementation
+│   ├── Type/          # DeviceContext implementation
+│   └── DeviceDetectionAwareTrait.php  # Request/device-info resolution shared by all context types
 ├── Dto/               # Data Transfer Objects
 └── Service/           # Device detection services
 ```

--- a/Classes/Context/DeviceDetectionAwareTrait.php
+++ b/Classes/Context/DeviceDetectionAwareTrait.php
@@ -1,0 +1,72 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+/**
+ * This file is part of the package netresearch/contexts-wurfl.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\ContextsDevice\Context;
+
+use Netresearch\ContextsDevice\Dto\DeviceInfo;
+use Netresearch\ContextsDevice\Service\DeviceDetectionService;
+use Psr\Http\Message\ServerRequestInterface;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * Resolves device information for the current request.
+ *
+ * Shared by every context type in this extension that decides on detected
+ * device properties. The service is injected via the constructor in normal
+ * operation; the lazy fallback covers the code paths where TYPO3 instantiates
+ * a context from a database row without going through the container.
+ *
+ * @author Netresearch DTT GmbH
+ * @link https://www.netresearch.de
+ */
+trait DeviceDetectionAwareTrait
+{
+    protected ?DeviceDetectionService $deviceDetectionService = null;
+
+    /**
+     * Get the device detection service, with lazy initialization fallback.
+     */
+    protected function getDeviceDetectionService(): DeviceDetectionService
+    {
+        if (!$this->deviceDetectionService instanceof DeviceDetectionService) {
+            $this->deviceDetectionService = GeneralUtility::makeInstance(DeviceDetectionService::class);
+        }
+
+        return $this->deviceDetectionService;
+    }
+
+    /**
+     * Get the current HTTP request.
+     */
+    protected function getRequest(): ?ServerRequestInterface
+    {
+        return $GLOBALS['TYPO3_REQUEST'] ?? null;
+    }
+
+    /**
+     * Get device information from the current request.
+     */
+    protected function getDeviceInfo(): ?DeviceInfo
+    {
+        $request = $this->getRequest();
+
+        if (!$request instanceof ServerRequestInterface) {
+            return null;
+        }
+
+        return $this->getDeviceDetectionService()->detectFromRequest($request);
+    }
+}

--- a/Classes/Context/Type/BrowserContext.php
+++ b/Classes/Context/Type/BrowserContext.php
@@ -83,7 +83,7 @@ class BrowserContext extends AbstractContext
         // Get device info
         $deviceInfo = $this->getDeviceInfo();
 
-        if ($deviceInfo === null) {
+        if (!$deviceInfo instanceof DeviceInfo) {
             return $this->storeInSession($this->invert(false));
         }
 
@@ -98,7 +98,7 @@ class BrowserContext extends AbstractContext
      */
     protected function getDeviceDetectionService(): DeviceDetectionService
     {
-        if ($this->deviceDetectionService === null) {
+        if (!$this->deviceDetectionService instanceof DeviceDetectionService) {
             $this->deviceDetectionService = GeneralUtility::makeInstance(DeviceDetectionService::class);
         }
 
@@ -120,7 +120,7 @@ class BrowserContext extends AbstractContext
     {
         $request = $this->getRequest();
 
-        if ($request === null) {
+        if (!$request instanceof ServerRequestInterface) {
             return null;
         }
 
@@ -141,8 +141,8 @@ class BrowserContext extends AbstractContext
         }
 
         $browsers = explode(',', $browsersConfig);
-        $browsers = array_map('trim', $browsers);
-        $browsers = array_map('strtolower', $browsers);
+        $browsers = array_map(trim(...), $browsers);
+        $browsers = array_map(strtolower(...), $browsers);
         $browsers = array_filter($browsers, static fn(string $browser): bool => $browser !== '');
 
         return array_values($browsers);

--- a/Classes/Context/Type/BrowserContext.php
+++ b/Classes/Context/Type/BrowserContext.php
@@ -17,10 +17,9 @@ declare(strict_types=1);
 namespace Netresearch\ContextsDevice\Context\Type;
 
 use Netresearch\Contexts\Context\AbstractContext;
+use Netresearch\ContextsDevice\Context\DeviceDetectionAwareTrait;
 use Netresearch\ContextsDevice\Dto\DeviceInfo;
 use Netresearch\ContextsDevice\Service\DeviceDetectionService;
-use Psr\Http\Message\ServerRequestInterface;
-use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * Context type that matches based on browser name.
@@ -44,7 +43,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  */
 class BrowserContext extends AbstractContext
 {
-    protected ?DeviceDetectionService $deviceDetectionService = null;
+    use DeviceDetectionAwareTrait;
 
     /**
      * @param array<string, mixed> $arRow Database context row
@@ -91,40 +90,6 @@ class BrowserContext extends AbstractContext
         $bMatch = $this->matchesBrowser($deviceInfo, $configuredBrowsers);
 
         return $this->storeInSession($this->invert($bMatch));
-    }
-
-    /**
-     * Get the device detection service, with lazy initialization fallback.
-     */
-    protected function getDeviceDetectionService(): DeviceDetectionService
-    {
-        if (!$this->deviceDetectionService instanceof DeviceDetectionService) {
-            $this->deviceDetectionService = GeneralUtility::makeInstance(DeviceDetectionService::class);
-        }
-
-        return $this->deviceDetectionService;
-    }
-
-    /**
-     * Get the current HTTP request.
-     */
-    protected function getRequest(): ?ServerRequestInterface
-    {
-        return $GLOBALS['TYPO3_REQUEST'] ?? null;
-    }
-
-    /**
-     * Get device information from the current request.
-     */
-    protected function getDeviceInfo(): ?DeviceInfo
-    {
-        $request = $this->getRequest();
-
-        if (!$request instanceof ServerRequestInterface) {
-            return null;
-        }
-
-        return $this->getDeviceDetectionService()->detectFromRequest($request);
     }
 
     /**

--- a/Classes/Context/Type/DeviceContext.php
+++ b/Classes/Context/Type/DeviceContext.php
@@ -86,7 +86,7 @@ class DeviceContext extends AbstractContext
         // Get device info
         $deviceInfo = $this->getDeviceInfo();
 
-        if ($deviceInfo === null) {
+        if (!$deviceInfo instanceof DeviceInfo) {
             return $this->storeInSession($this->invert(false));
         }
 
@@ -108,7 +108,7 @@ class DeviceContext extends AbstractContext
      */
     protected function getDeviceDetectionService(): DeviceDetectionService
     {
-        if ($this->deviceDetectionService === null) {
+        if (!$this->deviceDetectionService instanceof DeviceDetectionService) {
             $this->deviceDetectionService = GeneralUtility::makeInstance(DeviceDetectionService::class);
         }
 
@@ -130,7 +130,7 @@ class DeviceContext extends AbstractContext
     {
         $request = $this->getRequest();
 
-        if ($request === null) {
+        if (!$request instanceof ServerRequestInterface) {
             return null;
         }
 

--- a/Classes/Context/Type/DeviceContext.php
+++ b/Classes/Context/Type/DeviceContext.php
@@ -17,10 +17,9 @@ declare(strict_types=1);
 namespace Netresearch\ContextsDevice\Context\Type;
 
 use Netresearch\Contexts\Context\AbstractContext;
+use Netresearch\ContextsDevice\Context\DeviceDetectionAwareTrait;
 use Netresearch\ContextsDevice\Dto\DeviceInfo;
 use Netresearch\ContextsDevice\Service\DeviceDetectionService;
-use Psr\Http\Message\ServerRequestInterface;
-use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * Context type that matches based on device type (mobile/tablet/desktop/bot).
@@ -43,7 +42,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  */
 class DeviceContext extends AbstractContext
 {
-    protected ?DeviceDetectionService $deviceDetectionService = null;
+    use DeviceDetectionAwareTrait;
 
     /**
      * @param array<string, mixed> $arRow Database context row
@@ -101,40 +100,6 @@ class DeviceContext extends AbstractContext
         );
 
         return $this->storeInSession($this->invert($bMatch));
-    }
-
-    /**
-     * Get the device detection service, with lazy initialization fallback.
-     */
-    protected function getDeviceDetectionService(): DeviceDetectionService
-    {
-        if (!$this->deviceDetectionService instanceof DeviceDetectionService) {
-            $this->deviceDetectionService = GeneralUtility::makeInstance(DeviceDetectionService::class);
-        }
-
-        return $this->deviceDetectionService;
-    }
-
-    /**
-     * Get the current HTTP request.
-     */
-    protected function getRequest(): ?ServerRequestInterface
-    {
-        return $GLOBALS['TYPO3_REQUEST'] ?? null;
-    }
-
-    /**
-     * Get device information from the current request.
-     */
-    protected function getDeviceInfo(): ?DeviceInfo
-    {
-        $request = $this->getRequest();
-
-        if (!$request instanceof ServerRequestInterface) {
-            return null;
-        }
-
-        return $this->getDeviceDetectionService()->detectFromRequest($request);
     }
 
     /**

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -15,3 +15,11 @@ services:
   # No configuration needed - uses user-agent from request
   DeviceDetector\DeviceDetector:
     shared: false
+
+  # Must be public: context types are built by netresearch/contexts
+  # Factory::createFromDb() via GeneralUtility::makeInstance() with only the
+  # database row, so they resolve this service from the container themselves.
+  # Without public visibility the container lookup misses, makeInstance falls
+  # back to plain instantiation and dies on the required DeviceDetector.
+  Netresearch\ContextsDevice\Service\DeviceDetectionService:
+    public: true

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help cgl cgl-fix phpstan test test-unit test-functional
+.PHONY: help cgl cgl-fix phpstan rector rector-fix test test-unit test-functional
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
@@ -11,6 +11,12 @@ cgl-fix: ## Fix code style
 
 phpstan: ## Run PHPStan static analysis
 	composer ci:test:php:phpstan
+
+rector: ## Check Rector rules (dry-run)
+	composer ci:test:php:rector
+
+rector-fix: ## Apply Rector rules
+	composer ci:rector
 
 test: test-unit test-functional ## Run all tests
 

--- a/Tests/Architecture/LayerTest.php
+++ b/Tests/Architecture/LayerTest.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 
 namespace Netresearch\ContextsDevice\Tests\Architecture;
 
+use Netresearch\Contexts\Context\AbstractContext;
 use PHPat\Selector\Selector;
 use PHPat\Test\Builder\Rule;
 use PHPat\Test\PHPat;
@@ -36,7 +37,7 @@ final class LayerTest
             ->classes(Selector::inNamespace('Netresearch\ContextsDevice\Context\Type'))
             ->shouldExtend()
             ->classes(
-                Selector::classname('Netresearch\Contexts\Context\AbstractContext'),
+                Selector::classname(AbstractContext::class),
             )
             ->because('All context types should extend AbstractContext from the contexts extension');
     }

--- a/Tests/Functional/Context/DeviceDetectionAwareTraitTest.php
+++ b/Tests/Functional/Context/DeviceDetectionAwareTraitTest.php
@@ -1,0 +1,82 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+/**
+ * This file is part of the package netresearch/contexts-wurfl.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\ContextsDevice\Tests\Functional\Context;
+
+use Netresearch\ContextsDevice\Context\Type\DeviceContext;
+use Netresearch\ContextsDevice\Service\DeviceDetectionService;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
+
+/**
+ * Functional tests for the lazy service fallback in DeviceDetectionAwareTrait.
+ *
+ * Context types are built by netresearch/contexts Factory::createFromDb() via
+ * GeneralUtility::makeInstance() with only the database row, so the fallback is
+ * the production path. It requires DeviceDetectionService to be retrievable
+ * from the container; these tests pin that.
+ */
+final class DeviceDetectionAwareTraitTest extends FunctionalTestCase
+{
+    protected array $testExtensionsToLoad = [
+        'netresearch/contexts',
+        'netresearch/contexts-wurfl',
+    ];
+
+    /**
+     * Guards the `public: true` entry in Configuration/Services.yaml. Without
+     * it the container lookup misses and makeInstance() falls back to plain
+     * instantiation, which cannot satisfy the required DeviceDetector argument.
+     */
+    #[Test]
+    public function deviceDetectionServiceIsRetrievableFromTheContainer(): void
+    {
+        // getContainer() hands out the container of PUBLIC services only, so
+        // has() here really asserts public visibility. get() would also see
+        // non-public services and would pass without the fix.
+        self::assertTrue(
+            $this->getContainer()->has(DeviceDetectionService::class),
+            'DeviceDetectionService must be public so makeInstance() can resolve it',
+        );
+    }
+
+    #[Test]
+    public function makeInstanceResolvesTheAutowiredService(): void
+    {
+        self::assertInstanceOf(
+            DeviceDetectionService::class,
+            GeneralUtility::makeInstance(DeviceDetectionService::class),
+        );
+    }
+
+    #[Test]
+    public function contextWithoutInjectedServiceResolvesOneLazily(): void
+    {
+        // Mirrors Factory::createFromDb(): only the row, no service.
+        $context = new class ([]) extends DeviceContext {
+            public function resolveDeviceDetectionService(): DeviceDetectionService
+            {
+                return $this->getDeviceDetectionService();
+            }
+        };
+
+        self::assertInstanceOf(
+            DeviceDetectionService::class,
+            $context->resolveDeviceDetectionService(),
+        );
+    }
+}

--- a/Tests/Unit/Context/DeviceDetectionAwareTraitTest.php
+++ b/Tests/Unit/Context/DeviceDetectionAwareTraitTest.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+/**
+ * This file is part of the package netresearch/contexts-wurfl.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\ContextsDevice\Tests\Unit\Context;
+
+use DeviceDetector\DeviceDetector;
+use Netresearch\ContextsDevice\Context\DeviceDetectionAwareTrait;
+use Netresearch\ContextsDevice\Service\DeviceDetectionService;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for DeviceDetectionAwareTrait.
+ *
+ * Covers the injected branch of the service accessor. The lazy fallback needs a
+ * real container and is covered in the functional test of the same name.
+ */
+final class DeviceDetectionAwareTraitTest extends TestCase
+{
+    #[Test]
+    public function injectedServiceIsReturnedWithoutTouchingTheContainer(): void
+    {
+        // DeviceDetectionService is final, so the suite builds real instances
+        // rather than mocks (same as the context type tests).
+        $service = new DeviceDetectionService(new DeviceDetector());
+
+        $host = new class ($service) {
+            use DeviceDetectionAwareTrait;
+
+            public function __construct(DeviceDetectionService $service)
+            {
+                $this->deviceDetectionService = $service;
+            }
+
+            public function resolveDeviceDetectionService(): DeviceDetectionService
+            {
+                return $this->getDeviceDetectionService();
+            }
+        };
+
+        // Same instance: an injected service must never be replaced by a
+        // container lookup (GeneralUtility::makeInstance would fail here, as
+        // there is no container in a unit test).
+        self::assertSame($service, $host->resolveDeviceDetectionService());
+    }
+}

--- a/Tests/Unit/Context/Type/BrowserContextTest.php
+++ b/Tests/Unit/Context/Type/BrowserContextTest.php
@@ -338,9 +338,9 @@ final class BrowserContextTest extends TestCase
             $browsers,
             $invert,
         ) extends BrowserContext {
-            private string $testBrowsers;
+            private readonly string $testBrowsers;
 
-            private bool $testInvert;
+            private readonly bool $testInvert;
 
             public function __construct(
                 DeviceDetectionService $service,

--- a/Tests/Unit/Context/Type/DeviceContextTest.php
+++ b/Tests/Unit/Context/Type/DeviceContextTest.php
@@ -266,8 +266,8 @@ final class DeviceContextTest extends TestCase
 
         $context = $this->createTestableDeviceContext(
             service: $service,
-            isDesktop: true,  // Won't match
             isTablet: true,   // Will match
+            isDesktop: true,  // Won't match
         );
 
         self::assertTrue($context->match());
@@ -449,17 +449,17 @@ final class DeviceContextTest extends TestCase
             $isBot,
             $invert,
         ) extends DeviceContext {
-            private bool $testIsMobile;
+            private readonly bool $testIsMobile;
 
-            private bool $testIsPhone;
+            private readonly bool $testIsPhone;
 
-            private bool $testIsTablet;
+            private readonly bool $testIsTablet;
 
-            private bool $testIsDesktop;
+            private readonly bool $testIsDesktop;
 
-            private bool $testIsBot;
+            private readonly bool $testIsBot;
 
-            private bool $testInvert;
+            private readonly bool $testInvert;
 
             public function __construct(
                 DeviceDetectionService $service,

--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,7 @@
         "a9f/typo3-fractor": "^1.0.0",
         "friendsofphp/php-cs-fixer": "^3.92",
         "infection/infection": "*",
+        "netresearch/typo3-ci-workflows": "^1.3",
         "phpat/phpat": "^0.12",
         "phpstan/phpstan": "^2.1",
         "phpstan/phpstan-deprecation-rules": "^2.0",
@@ -55,7 +56,9 @@
     "config": {
         "allow-plugins": {
             "a9f/fractor-extension-installer": true,
+            "captainhook/hook-installer": true,
             "infection/extension-installer": true,
+            "phpstan/extension-installer": false,
             "typo3/class-alias-loader": true,
             "typo3/cms-composer-installers": true
         },
@@ -75,9 +78,11 @@
     },
     "scripts": {
         "ci:cgl": ".Build/bin/php-cs-fixer fix",
+        "ci:rector": ".Build/bin/rector process --config Build/rector.php",
         "ci:test:php:cgl": ".Build/bin/php-cs-fixer fix --dry-run --diff",
         "ci:test:php:functional": ".Build/bin/phpunit -c Build/phpunit/FunctionalTests.xml",
         "ci:test:php:phpstan": ".Build/bin/phpstan analyse -c Build/phpstan.neon",
+        "ci:test:php:rector": ".Build/bin/rector process --config Build/rector.php --dry-run",
         "ci:test:php:unit": ".Build/bin/phpunit -c Build/phpunit/UnitTests.xml",
         "test:coverage": "XDEBUG_MODE=coverage .Build/bin/phpunit -c Build/phpunit/UnitTests.xml --coverage-html .Build/coverage",
         "test:mutation": ".Build/bin/infection --threads=4 --show-mutations"

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -7,6 +7,6 @@
 
 declare(strict_types=1);
 
-defined('TYPO3') or die();
+defined('TYPO3') || die();
 
 // Context types are registered via Configuration/TCA/Overrides/tx_contexts_contexts.php


### PR DESCRIPTION
`contexts_wurfl` had no Rector configuration at all, so the fleet-wide rule baseline never reached it. This adds `Build/rector.php` on top of the shared config from [netresearch/typo3-ci-workflows v1.3.4](https://github.com/netresearch/typo3-ci-workflows/releases/tag/v1.3.4), wires it into the two composer scripts the reusable CI workflow looks for (`ci:rector` to apply, `ci:test:php:rector` for the dry-run the [Rector job](https://github.com/netresearch/typo3-ci-workflows/blob/main/.github/workflows/ci.yml) greps for), exposes both through the Makefile next to the existing `cgl`/`phpstan` targets, and commits the fixes Rector produced on its first application. Same procedure as [t3x-nr-image-optimize#150](https://github.com/netresearch/t3x-nr-image-optimize/pull/150) and [t3x-nr-textdb#109](https://github.com/netresearch/t3x-nr-textdb/pull/109).

Why the shared config rather than a local one: the org config *is* the rule baseline. Sourcing it from the meta package means an upstream problem gets fixed once, centrally — the [Rector 2.6.0 breakage of 2026-08-03](https://github.com/netresearch/typo3-ci-workflows/pull/154), where the removed `SetList::STRICT_BOOLEANS` killed every consumer's Rector job, is exactly the failure mode this avoids repeating per extension. No TYPO3 level set is enabled yet; that is deliberately a follow-up, tracked in typo3-ci-workflows#155.

The `^12.4` matrix cells need a guard, and it is in this same commit. The meta package is unresolvable under `typo3/cms-core ^12.4` because `saschaegerer/phpstan-typo3 ^2||^3` requires `cms-core >=13.4`, so `netresearch/typo3-ci-workflows` joins the existing `remove-dev-deps` entry and is dropped for anything that is not `^13.4`/`^14.3`. I verified both directions locally by replicating what the workflow does in that cell: with the guard the `^12.4` cell installs, keeps PHPStan 2.2.7 and PHPUnit 11.5.56, and passes both PHPStan and the unit suite; without it Composer fails with exactly the conflict above. Because those cells run without the meta package, the local `rector`/`phpstan`/`phpunit` pins stay in `require-dev` — they are the toolchain those cells use.

`phpstan/extension-installer` is set to `false` rather than `true`. `Build/phpstan.neon` includes the strict-rules, deprecation-rules and phpunit extension neons explicitly, so letting the installer register them as well breaks PHPStan with "This file is included multiple times" (the finding from [t3x-contexts#167](https://github.com/netresearch/t3x-contexts/pull/167)). Explicit `false` keeps today's behaviour and suppresses the Composer prompt; converting the neon to installer-registered extensions is its own migration, not part of enabling Rector.

One Rector change needed a manual correction rather than being waved through. `SortCallLikeNamedArgsRector` reordered the named arguments of a `createTestableDeviceContext()` call into parameter order but left the trailing comments in place, so `// Will match` and `// Won't match` ended up describing the wrong arguments. The arguments are semantically order-independent, so the sort itself is fine — the comments were moved back onto the arguments they actually describe. The rest of the diff is `ReadOnlyPropertyRector` on already-private test-stub properties, null-check to `instanceof` rewrites, first-class callables in `array_map`, and one FQCN turned into an import. No `protected` property was privatised anywhere, so the `PrivatizeFinalClassPropertyRector` hazard does not apply here: the repo has no Extbase domain models, no scheduler tasks, no traits, and its two `final` classes have no `protected` properties.

Verification used a CI-matched toolchain — cold install with `platform.php` pinned to 8.3 (the version the Rector job runs), vendor and lock removed first so no warm vendor could mask a blocked plugin. Rector reaches a fixpoint after one apply round, alternating CGL runs change nothing, PHPStan stays at level 10 with no errors, and 95 unit plus 8 functional tests pass — identical to the pre-Rector baseline I measured before touching anything. Both mandatory greps for the known Rector regression classes (literal closure return types, deleted inline `@var` above `return`) come back empty. The platform pin was removed again before committing; no `composer.lock` is committed.

The second commit removes the 36-line block that `BrowserContext` and `DeviceContext` each carried — the nullable service property, the lazy `getDeviceDetectionService()`, `getRequest()` and `getDeviceInfo()` — into one `Netresearch\ContextsDevice\Context\DeviceDetectionAwareTrait`. SonarCloud had failed the gate on `new_duplicated_lines_density` at 7.3% against a threshold of 3, because the Rector rewrite touched lines inside that twin block; it is now 0.0%, and overall duplication dropped from 5.6% to 3.6%. The trait sits one namespace above `Context\Type` deliberately: the PHPat rule in `Tests/Architecture/LayerTest.php` asserts everything in `Context\Type` extends `AbstractContext` and its namespace selector matches by prefix, so a trait placed beside the context types would be pulled into that rule and reported for extending nothing. This also keeps both classes extending `AbstractContext` directly, rather than inserting an intermediate base class purely to share code.

The third commit fixes a defect that extraction exposed, and it is worth reading as its own change. The lazy fallback could never succeed: `netresearch/contexts` builds context types in `Factory::createFromDb()` via `GeneralUtility::makeInstance($class, $arRow)` with only the database row and no service, so every context loaded from the database resolves the service itself on first use — but `Services.yaml` declared `public: false` for everything, so the container lookup missed, `makeInstance()` fell back to plain instantiation and died with `ArgumentCountError` on the required `DeviceDetector`. With a real request present, device matching fataled. The existing tests never caught it because they `unset($GLOBALS['TYPO3_REQUEST'])`, which makes `getRequest()` return null so `getDeviceInfo()` bails out before the service is needed. The defect predates this branch — the identical fallback lived in both context classes before it was extracted.

Declaring `DeviceDetectionService` as `public: true` is the documented way to reach a service from outside dependency injection, and it is what this extension family already does: `netresearch/contexts` carries a "Services that need to be public for TYPO3's service locator" block for `DataHandlerService`, `PageService`, `IconService` and `FrontendControllerService`, and TYPO3 core marks makeInstance-reachable services the same way (for example `ResourceConsistencyService`). I measured `shared: false` as an alternative and rejected it: it governs instance sharing, not container visibility, so on its own `has()` still answers false and `makeInstance()` still throws. Factory-side injection was rejected too — that contract lives upstream in `netresearch/contexts` and changing it would alter how every context type in every satellite extension is built, to fix one extension's service.

Three regression tests cover both states of the service reference. The unit test asserts an injected service is returned unchanged with no container lookup; the functional tests assert the container exposes the service publicly and that a context constructed the way the Factory constructs it resolves one lazily. The public-visibility assertion deliberately uses the framework's `getContainer()`, which hands out public services only — `get()` also sees non-public services and would have passed even without the fix. I verified the tests actually guard the fix rather than merely passing alongside it: with the `Services.yaml` entry removed all three fail (one assertion failure plus two `ArgumentCountError`), with it in place all three pass.

Whether the sibling extensions share this pattern is tracked separately in #43. Final state of the full chain: 96 unit and 11 functional tests green, PHPStan level 10 without errors, CGL clean, Rector at a fixpoint with `--clear-cache`, `php -l` on every new file, `yaml-lint` on `Services.yaml`, and the SonarCloud gate green.

No version bump and no CHANGELOG entry: versioning belongs to the separate release flow.

