### PR TITLE
fix(deps): stop capping saschaegerer/phpstan-typo3 at 2.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,6 @@
         "phpstan/phpstan-strict-rules": "^2.0",
         "phpunit/phpunit": "^10.5 || ^11.0 || ^12.0",
         "rector/rector": "^2.3",
-        "saschaegerer/phpstan-typo3": "^2.0",
         "ssch/typo3-rector": "^3.11",
         "typo3/testing-framework": "^8.2 || ^9.0"
     },


### PR DESCRIPTION
Found during a fleet sweep for constraints that hold back analysis tooling, alongside [netresearch/typo3-ci-workflows#158](https://github.com/netresearch/typo3-ci-workflows/pull/158).

This repo requires `netresearch/typo3-ci-workflows`, which declares `saschaegerer/phpstan-typo3: ^2.0 || ^3.0`, and then declares it again locally as `^2.0`. Composer intersects the two, so the narrower local line wins and 3.x never reaches this repo. Latest is **3.1.0**, so the TYPO3-specific PHPStan rules added in 3.x have been silently missing here while every other consumer of the shared package receives them.

Across 21 consumers of the shared package this was the only constraint that actually caps below what the shared package allows — the other duplicated declarations all permit the newest release.

The line is dropped rather than widened to match: the shared package already states the constraint, and a second copy is only a place for the next cap to appear unnoticed. Ten further packages here duplicate shared declarations harmlessly; those are left for a fleet-wide pass rather than mixed into this fix.

Expect new PHPStan findings once 3.x resolves — that is the point of unblocking it.