### PR TITLE
chore(deps): allow the composer-normalize plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -54,6 +54,7 @@
     },
     "config": {
         "allow-plugins": {
+            "ergebnis/composer-normalize": true,
             "a9f/fractor-extension-installer": true,
             "captainhook/hook-installer": true,
             "infection/extension-installer": true,

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "a9f/typo3-fractor": "^1.0.0",
         "friendsofphp/php-cs-fixer": "^3.92",
         "infection/infection": "*",
-        "netresearch/typo3-ci-workflows": "^1.3",
+        "netresearch/typo3-ci-workflows": "^1.4",
         "phpat/phpat": "^0.12",
         "phpstan/phpstan": "^2.1",
         "phpstan/phpstan-deprecation-rules": "^2.0",
@@ -54,9 +54,9 @@
     },
     "config": {
         "allow-plugins": {
-            "ergebnis/composer-normalize": true,
             "a9f/fractor-extension-installer": true,
             "captainhook/hook-installer": true,
+            "ergebnis/composer-normalize": true,
             "infection/extension-installer": true,
             "phpstan/extension-installer": false,
             "typo3/class-alias-loader": true,


### PR DESCRIPTION
Scope corrected. This PR adds `ergebnis/composer-normalize` to `config.allow-plugins` — the shared package ships it as of v1.4.0, and a Composer plugin that is not allowed is installed but never runs — and raises the `netresearch/typo3-ci-workflows` constraint from `^1.3` to `^1.4`, so that `composer.json` declares the version the new entry depends on. The key sits in alphabetical position in the block, which is where `composer-normalize` itself sorts it, between `captainhook/hook-installer` and `infection/extension-installer`.

## Correction: why `^1.4`, and a claim withdrawn

An earlier version of this description, and of the commit message it belongs to, justified the bump as a guard against a `1.3.x` resolution carrying no `composer-normalize`. That is wrong and is withdrawn here. A caret takes the highest matching release, so with v1.4.0 published, `^1.2` and `^1.3` both resolve to v1.4.0 — there was never a resolution to guard against. Measured in an empty project with an empty `COMPOSER_CACHE_DIR` and no committed lock file:

```
require-dev: {"netresearch/typo3-ci-workflows": "^1.2"}

$ composer update --dry-run
  - Locking ergebnis/composer-normalize (2.52.0)
  - Locking netresearch/typo3-ci-workflows (v1.4.0)
```

`^1.4` stays for a different reason. This repo does not declare `ergebnis/composer-normalize` anywhere itself, so the only thing that can install it is `netresearch/typo3-ci-workflows`, and only from v1.4.0 — v1.3.3 and v1.3.4 do not ship it. `^1.3` therefore declared less than this branch assumes. It is a declaration fix, not a fix for a resolution that was ever broken.

## Why the dedup was dropped from this PR

It originally also removed the dev-dependencies `netresearch/typo3-ci-workflows` provides. That is wrong for this repo, and this repo's own CI said so plainly — job [`ci / PHPStan (8.4, ^12.4)`](https://github.com/netresearch/t3x-contexts_wurfl/actions/runs/30989287147/job/92251385273) on the since-replaced commit `28fe5902`:

```
Removing netresearch/typo3-ci-workflows (only compatible with ^13.4|^14.3)
...
sh: 1: .Build/bin/phpstan: not found
Script .Build/bin/phpstan analyse -c Build/phpstan.neon handling the ci:test:php:phpstan event returned with error code 127
```

`.github/workflows/ci.yml` carries

```yaml
remove-dev-deps: '[{"dep":"saschaegerer/phpstan-typo3","only-for":"^13"},{"dep":"netresearch/typo3-ci-workflows","only-for":"^13.4|^14.3"}]'
```

so on the **TYPO3 12.4 matrix legs the shared package is removed entirely** — it is not compatible there. On those legs the local declarations are the only source of phpstan, rector, php-cs-fixer and the testing framework. They are not duplicates at all; they are load-bearing, and they stay.

## What I got wrong

The safety net for this pass was a before/after `composer update --dry-run` comparison, and it reported the resolution unchanged. It was measuring the **default** resolution — one of several distinct resolutions the matrix produces. `ci.yml` declares `php-versions: '["8.3","8.4","8.5"]'` and `typo3-versions: '["^12.4","^13.4"]'`, which expands to five PHP/TYPO3 combinations in the run — 8.3 and 8.4 against both TYPO3 versions, 8.5 against `^13.4` only. The 12.4 legs resolve differently by design, and no amount of care in reading constraints would have shown it: only running the matrix does.

Repos without a `remove-dev-deps` directive for the shared package are unaffected, and their dedup PRs stay as they are.
