### PR TITLE
ci: pin harden-runner v2.21.0, matching the template

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -126,7 +126,7 @@ jobs:
     permissions: {}
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
         with:
           egress-policy: audit
 


### PR DESCRIPTION
The shared template moved to harden-runner v2.21.0 in netresearch/.github#380, so this repository's v2.20.1 now fails `drift / Template drift` for trailing it. Nine of the twenty `typo3-extension` consumers were already ahead of the template before that merge and had been failing the same check for the opposite reason; this closes the gap from the other side.

Same SHA the template carries, read from `step-security/harden-runner`'s own `v2.21.0` tag ref rather than copied from a sibling repository. The tag is lightweight and points straight at that commit.

One line in `.github/workflows/checks.yml`, which is the only template-governed file that pins this action. Verified before and after with `yq` against the parsed document rather than by matching text, so a pin hiding in a different key could not pass as done.

Refs netresearch/.github#379