### PR TITLE
docs(agents): sync AGENTS.md files and adopt agent-harness verification

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Pre-commit hook: keep AGENTS.md/docs consistent with the repo state.
+# Registered via composer post-install-cmd (git config core.hooksPath .githooks).
+# Exit 2 from verify-harness.sh means warnings only and must not block the commit.
+set -u
+
+bash Build/Scripts/verify-harness.sh
+rc=$?
+if [ "$rc" -ne 0 ] && [ "$rc" -ne 2 ]; then
+    echo "verify-harness.sh failed (exit $rc) -- fix AGENTS.md/docs drift before committing." >&2
+    exit 1
+fi
+exit 0

--- a/.github/workflows/harness-verify.yml
+++ b/.github/workflows/harness-verify.yml
@@ -1,0 +1,23 @@
+name: Harness Verification
+
+# Verifies agent-harness consistency (AGENTS.md line budget, dead references,
+# documented commands vs composer.json/Makefile, docs/ structure) via
+# Build/Scripts/verify-harness.sh. Thin caller of the shared script-check
+# reusable, so the checkout pin and harden-runner are maintained centrally.
+# Exit 2 means warnings only and passes; exit 1 (errors) fails the check.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  harness-verify:
+    uses: netresearch/.github/.github/workflows/script-check.yml@main
+    permissions:
+      contents: read
+    with:
+      check-cmd: bash Build/Scripts/verify-harness.sh || [ $? -eq 2 ]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,40 +1,11 @@
-<!-- Managed by agent: keep sections & order; edit content, not structure. Last updated: 2026-01-28 -->
+<!-- Managed by agent: keep sections & order; edit content, not structure. Last updated: 2026-08-19 -->
 
 # AGENTS.md
 
-**Project:** netresearch/contexts_device — Device detection context types for TYPO3
-**Type:** TYPO3 CMS Extension (PHP 8.2+, TYPO3 12.4/13.4)
-**Status:** LEGACY - Complete rewrite planned for TYPO3 v12/v13
+**Project:** `netresearch/contexts-wurfl` — device detection context types for TYPO3 (extension key `contexts_wurfl`, PHP namespace `Netresearch\ContextsDevice`)
+**Type:** TYPO3 CMS Extension (PHP ^8.2, TYPO3 12.4/13.4 — version: see `ext_emconf.php`)
 
-> **Important:** This is currently a LEGACY extension (TYPO3 4.5-6.2, PHP 5.x) named `contexts_wurfl`.
-> This AGENTS.md documents the TARGET architecture for the upcoming complete rewrite.
-> The extension will be renamed to `contexts_device` and use Matomo DeviceDetector.
-> Do NOT reference current legacy code patterns during rewrite.
-
-## Architectural Decision: Matomo DeviceDetector
-
-**Library:** `matomo/device-detector` ^6.0 (NOT the bundled WURFL library)
-
-**Rationale:**
-- Higher update frequency (crucial for detecting new devices)
-- Larger community (Matomo user base)
-- Industry leader for PHP device detection
-- No database required (pure PHP, regex-based)
-- MIT licensed
-
-**WURFL Capability Loss Warning:**
-Users relying on WURFL's exhaustive device capability flags will lose this functionality:
-- Screen dimensions (resolution_width, resolution_height) - NOT available
-- Java support - NOT available
-- Specific hardware features - NOT available
-
-**Available in Matomo DeviceDetector:**
-- Device type (mobile, tablet, desktop, tv, console, car browser, etc.)
-- Operating system (name, version, family)
-- Browser (name, version, engine)
-- Brand/manufacturer
-- Model name
-- Bot detection
+Device detection uses `matomo/device-detector` — the historical WURFL library was replaced in v2.0.0 (see `docs/adr/0001-replace-wurfl-with-device-detector.md` and `Documentation/Migration/Index.rst`). Component map: `docs/ARCHITECTURE.md`.
 
 ## Precedence
 
@@ -46,176 +17,80 @@ The **closest AGENTS.md** to changed files wins. This root file holds global def
 - Conventional Commits: `type(scope): subject`
 - Ask before: heavy dependencies, architecture changes, new context types
 - Never commit secrets, credentials, or PII
-- GrumPHP runs pre-commit checks automatically
+- Update AGENTS.md/docs in the same PR when commands, CI, or structure change (`Build/Scripts/verify-harness.sh` checks this in CI)
 
-## Pre-Commit Checks (GrumPHP)
+## Commands
 
 ```bash
-# Automatic on commit (via GrumPHP):
-composer ci:test:php:cgl      # PHP-CS-Fixer (PSR-12 + TYPO3 CGL)
-composer ci:test:php:phpstan  # PHPStan level 8
-
-# Manual testing:
 composer ci:test:php:unit        # PHPUnit unit tests
 composer ci:test:php:functional  # PHPUnit functional tests (needs DB)
-composer test:coverage           # Coverage report (needs PCOV/Xdebug)
-
-# Fix commands (for local development):
-composer ci:cgl               # Fix code style
+composer ci:test:php:phpstan     # PHPStan (Build/phpstan.neon)
+composer ci:test:php:cgl         # PHP-CS-Fixer check (dry-run)
+composer ci:test:php:rector      # Rector check (dry-run, Build/rector.php)
+composer ci:cgl                  # Fix code style
+composer ci:rector               # Apply Rector rules
+composer test:coverage           # Coverage report (needs Xdebug)
+composer test:mutation           # Infection mutation testing
 ```
+
+The `Makefile` mirrors these: `make cgl | cgl-fix | phpstan | rector | rector-fix | test | test-unit | test-functional`.
 
 ## Development Environment
 
 ```bash
-# DDEV setup (recommended)
 ddev start
-ddev install-all          # Install TYPO3 v12, v13
+ddev install-all          # Install TYPO3 v12 + v13 test instances
 
-# Access
-https://v12.contexts-device.ddev.site/typo3/    # TYPO3 v12 backend
-https://v13.contexts-device.ddev.site/typo3/    # TYPO3 v13 backend
-
-# Credentials: admin / Password:joh316
+# Backends (credentials: admin / joh316)
+https://v12.contexts-wurfl.ddev.site/typo3/
+https://v13.contexts-wurfl.ddev.site/typo3/
 ```
 
 ## CI Workflows
 
 | Workflow | Trigger | Purpose |
 |----------|---------|---------|
-| `ci.yml` | push/PR | Full test suite (unit, functional, lint, phpstan) |
-| `phpstan.yml` | push/PR | Static analysis |
-| `phpcs.yml` | push/PR | Code style |
-| `security.yml` | schedule | Dependency vulnerability scan |
-| `publish-to-ter.yml` | tag | Publish to TYPO3 Extension Repository |
+| `ci.yml` | push/PR/merge_group/weekly | Unit+functional matrix (PHP 8.3–8.5 × TYPO3 ^12.4/^13.4) via `netresearch/typo3-ci-workflows` |
+| `checks.yml` | push/PR/merge_group/weekly | Security/quality: CodeQL, gitleaks, zizmor, fuzz, license check, Scorecard, dependency review, PR quality gate |
+| `harness-verify.yml` | push/PR | Agent-harness consistency (`Build/Scripts/verify-harness.sh`) |
+| `release.yml` | tag `v*` | Release to TER/Packagist/docs via `release-typo3-extension.yml` |
+| `republish.yml` | manual | Re-run publish targets (ter/docs/packagist) for an existing tag |
 
-## Project Structure (Target)
+## Project Structure
 
 ```
-Classes/                       # PHP source code
-├── Context/Type/              # Context type implementations
-│   ├── DeviceContext.php      # Mobile/Tablet/Desktop matching
-│   └── BrowserContext.php     # Browser name/version matching
-├── Service/                   # Business logic services
-│   └── DeviceDetectionService.php
-├── Dto/                       # Value objects for device data
-│   └── DeviceInfo.php
-└── Exception/                 # Custom exceptions
-    └── DeviceDetectionException.php
-Tests/                         # Test suite
-├── Unit/                      # Unit tests
-│   ├── Context/Type/
-│   └── Service/
-└── Functional/                # Functional tests
-Configuration/                 # TYPO3 configuration
-├── TCA/Overrides/
-├── FlexForms/
-├── Services.yaml
-└── SiteSet/                   # v13 site sets
-Resources/                     # Language files, assets
-Documentation/                 # RST documentation
+Classes/
+├── Context/
+│   ├── DeviceDetectionAwareTrait.php  # Request/device-info resolution shared by context types
+│   └── Type/                          # DeviceContext, BrowserContext
+├── Dto/                               # DeviceInfo (readonly)
+└── Service/                           # DeviceDetectionService (matomo/device-detector wrapper)
+Configuration/          # TCA/Overrides, FlexForms, Services.yaml, Icons.php
+Tests/                  # Unit/, Functional/, Architecture/ (PHPat)
+Documentation/          # RST docs for docs.typo3.org
+docs/                   # ADRs, ARCHITECTURE.md, exec-plans/
+Build/                  # phpunit/phpstan/rector configs, Scripts/
 ```
 
 ## Index of Scoped AGENTS.md
 
 | Path | Purpose |
 |------|---------|
-| `Classes/AGENTS.md` | PHP backend code, device detection service, context types |
+| [Classes/AGENTS.md](./Classes/AGENTS.md) | PHP source: context types, detection service, DTOs |
+| [Configuration/AGENTS.md](./Configuration/AGENTS.md) | TCA overrides, FlexForms, DI configuration |
+| [Tests/AGENTS.md](./Tests/AGENTS.md) | Unit, functional, and architecture tests |
+| [Documentation/AGENTS.md](./Documentation/AGENTS.md) | RST documentation for docs.typo3.org |
 
 ## Dependencies
 
-**Required:**
-- `netresearch/contexts` ^2.0 - Base contexts extension
-- `matomo/device-detector` ^6.0 - Device detection library
-
-**Optional (for cache warming):**
-- PSR-16 simple cache implementation
+- `netresearch/contexts` `^3.1.1 || ^4.0` — base contexts extension (`AbstractContext`)
+- `matomo/device-detector` `^6.0` — user agent parsing (regex-based, no database)
 
 ## Key Concepts
 
-### Matomo DeviceDetector Integration
-
-```php
-use DeviceDetector\DeviceDetector;
-use DeviceDetector\Parser\Client\Browser;
-
-$dd = new DeviceDetector($userAgent);
-$dd->parse();
-
-// Device type detection
-$dd->isMobile();     // Phone or Tablet
-$dd->isTablet();     // Tablet specifically
-$dd->isDesktop();    // Desktop/Laptop
-$dd->isBot();        // Bot/Crawler
-
-// Device information
-$dd->getDeviceName();     // e.g., "smartphone", "tablet", "desktop"
-$dd->getBrandName();      // e.g., "Apple", "Samsung"
-$dd->getModel();          // e.g., "iPhone 15", "Galaxy S24"
-
-// OS information
-$dd->getOs('name');       // e.g., "iOS", "Android", "Windows"
-$dd->getOs('version');    // e.g., "17.2", "14", "11"
-
-// Browser information
-$dd->getClient('name');   // e.g., "Chrome", "Safari", "Firefox"
-$dd->getClient('version');// e.g., "120.0", "17.2"
-```
-
-### Context Types
-
-| Context Type | Purpose | Configuration Fields |
-|-------------|---------|---------------------|
-| `DeviceContext` | Match by device type | Device types (mobile, tablet, desktop, tv, etc.) |
-| `BrowserContext` | Match by browser | Browser names, version patterns |
-
-### Device Type Mapping (WURFL to Matomo)
-
-| WURFL Capability | Matomo DeviceDetector |
-|-----------------|----------------------|
-| `is_wireless_device` | `isMobile()` |
-| `is_tablet` | `isTablet()` |
-| `can_assign_phone_number` | `isMobile() && !isTablet()` |
-| `is_smarttv` | `isTv()` |
-| `brand_name` | `getBrandName()` |
-| `model_name` | `getModel()` |
-| `mobile_browser` | `getClient('name')` |
-| `resolution_width` | NOT AVAILABLE |
-| `resolution_height` | NOT AVAILABLE |
-
-## Configuration
-
-### Extension Configuration (ext_conf_template.txt)
-
-```
-# Cache parsed results (recommended for production)
-enableCache = 1
-
-# Bot detection behavior
-treatBotsAsDesktop = 1
-
-# Client hints support (for modern browsers)
-enableClientHints = 1
-```
-
-## Migration from WURFL
-
-### Breaking Changes
-
-1. **No Screen Dimensions**: `screenWidthMin`, `screenWidthMax`, `screenHeightMin`, `screenHeightMax` are removed. Use responsive CSS instead.
-
-2. **Simplified Device Types**: "Wireless" concept removed. Use "Mobile" which covers all non-desktop devices.
-
-3. **Database Removed**: No more WURFL database import CLI. DeviceDetector uses bundled regex files.
-
-### Migration Path
-
-```php
-// Old WURFL check
-$wurfl->isWireless(); // Check for wireless capability
-
-// New DeviceDetector equivalent
-$dd->isMobile();      // Check for mobile/tablet
-```
+- `DeviceContext` matches by device type (mobile, tablet, desktop, …); `BrowserContext` matches by browser name. Both extend `AbstractContext` from `netresearch/contexts`.
+- `DeviceDetectionService` wraps Matomo DeviceDetector; results travel as the readonly `DeviceInfo` DTO.
+- WURFL capability mapping and its limitations (e.g. no screen dimensions) are documented in `Documentation/Migration/Index.rst`.
 
 ## When Instructions Conflict
 
@@ -224,9 +99,8 @@ Nearest AGENTS.md wins. User prompts override files.
 ## Resources
 
 - [Matomo DeviceDetector](https://github.com/matomo-org/device-detector)
-- [DeviceDetector Demo](https://devicedetector.io/)
-- [TYPO3 Coding Guidelines](https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/CodingGuidelines/Index.html)
 - [Base Extension](https://github.com/netresearch/t3x-contexts)
+- [TYPO3 Coding Guidelines](https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/CodingGuidelines/Index.html)
 - [GitHub Issues](https://github.com/netresearch/t3x-contexts_wurfl/issues)
 
 ## Commit Signing

--- a/Build/Scripts/verify-harness.sh
+++ b/Build/Scripts/verify-harness.sh
@@ -1,0 +1,756 @@
+#!/usr/bin/env bash
+# verify-harness.sh — Portable harness consistency checker
+# Checks AGENTS.md and related files for agent harness maturity.
+# Dependencies: coreutils + git (jq optional, graceful fallback)
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Globals
+# ---------------------------------------------------------------------------
+ERRORS=0
+WARNINGS=0
+FORMAT=""
+MAX_LEVEL=3
+SINGLE_CHECK=""
+STATUS_ONLY=false
+PLATFORM="${PLATFORM:-}"
+
+# Collected output lines (for final rendering)
+declare -a OUTPUT_LINES=()
+declare -a GITHUB_LINES=()
+declare -a GITLAB_LINES=()
+
+# Per-level pass/total counters
+declare -A LEVEL_PASS=( [1]=0 [2]=0 [3]=0 )
+declare -A LEVEL_TOTAL=( [1]=0 [2]=0 [3]=0 )
+
+# Track the first failing level-1 suggestion for --status
+NEXT_STEP=""
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+usage() {
+    cat <<'USAGE'
+Usage: verify-harness.sh [OPTIONS]
+
+Verify agent harness consistency in the current repository.
+Must be run from the repo root.
+
+Options:
+  --format=text     Plain text output (default for terminals)
+  --format=github   GitHub Actions annotations (auto-detected in CI)
+  --format=gitlab   GitLab CI section annotations (auto-detected in CI)
+  --platform=P      Target platform: github, gitlab or forgejo (auto-detected
+                    from CI environment or git remote URL if not specified)
+  --level=N         Only check up to level N (1, 2, or 3; default: all)
+  --check=NAME      Run single check category: refs, commands, drift, structure
+  --status          Show current maturity level summary only
+  --help            Show this help message
+
+Exit codes:
+  0  All checks pass
+  1  Errors found (Level 1/2 failures)
+  2  Only warnings (Level 3 suggestions)
+USAGE
+    exit 0
+}
+
+# Detect output format: github if running in CI, otherwise text
+detect_format() {
+    if [[ -n "$FORMAT" ]]; then
+        return
+    fi
+    if [[ "${GITHUB_ACTIONS:-}" == "true" ]]; then
+        FORMAT="github"
+    elif [[ "${GITLAB_CI:-}" == "true" ]]; then
+        FORMAT="gitlab"
+    else
+        FORMAT="text"
+    fi
+}
+
+# Detect hosting platform from CI env, git remote, or flag
+detect_platform() {
+    if [[ -n "$PLATFORM" ]]; then
+        if [[ "$PLATFORM" != "github" && "$PLATFORM" != "gitlab" && "$PLATFORM" != "forgejo" ]]; then
+            echo "Error: Unsupported PLATFORM '${PLATFORM}'. Expected 'github', 'gitlab' or 'forgejo'." >&2
+            exit 1
+        fi
+        return
+    fi
+    if [[ "${GITHUB_ACTIONS:-}" == "true" ]]; then
+        # Forgejo/Gitea Actions also export GITHUB_ACTIONS=true; tell them apart
+        # by the server URL — github.com (or a *.github.* Enterprise host) is real
+        # GitHub, anything else is a self-hosted Forgejo/Gitea instance.
+        if [[ -n "${GITHUB_SERVER_URL:-}" && "${GITHUB_SERVER_URL}" != *"github."* ]]; then
+            PLATFORM="forgejo"
+        else
+            PLATFORM="github"
+        fi
+        return
+    fi
+    if [[ "${GITLAB_CI:-}" == "true" ]]; then
+        PLATFORM="gitlab"
+        return
+    fi
+    local remote_url=""
+    remote_url=$(git remote get-url origin 2>/dev/null || true)
+    if [[ "$remote_url" == *"forgejo"* || "$remote_url" == *"gitea"* ]]; then
+        PLATFORM="forgejo"
+    elif [[ "$remote_url" == *"github"* ]]; then
+        PLATFORM="github"
+    elif [[ "$remote_url" == *"gitlab"* ]]; then
+        PLATFORM="gitlab"
+    elif [[ -f ".gitlab-ci.yml" ]]; then
+        # Infer GitLab from CI config presence (e.g. self-hosted GitLab)
+        PLATFORM="gitlab"
+    elif [[ -d ".forgejo" || -d ".gitea" ]]; then
+        # Infer Forgejo/Gitea from config presence (self-hosted)
+        PLATFORM="forgejo"
+    elif [[ -d ".github" ]]; then
+        PLATFORM="github"
+    else
+        PLATFORM="github"
+    fi
+}
+
+# Record a passing check
+pass() {
+    local level="$1"
+    local msg="$2"
+    (( LEVEL_PASS[$level]++ )) || true
+    (( LEVEL_TOTAL[$level]++ )) || true
+    OUTPUT_LINES+=("  PASS|${level}|${msg}")
+}
+
+# Record a failing check (error)
+fail() {
+    local level="$1"
+    local msg="$2"
+    local file="${3-AGENTS.md}"
+    (( ERRORS++ )) || true
+    (( LEVEL_TOTAL[$level]++ )) || true
+    OUTPUT_LINES+=("  FAIL|${level}|${msg}")
+    GITHUB_LINES+=("::error file=${file}::${msg} -- required for Level ${level} harness maturity")
+    GITLAB_LINES+=("ERROR: [Level ${level}] ${msg}${file:+ (${file})}")
+    # Capture first actionable suggestion for --status
+    if [[ -z "$NEXT_STEP" ]]; then
+        NEXT_STEP="$msg"
+    fi
+}
+
+# Record a warning
+warn() {
+    local level="$1"
+    local msg="$2"
+    local file="${3-AGENTS.md}"
+    (( WARNINGS++ )) || true
+    (( LEVEL_TOTAL[$level]++ )) || true
+    OUTPUT_LINES+=("  WARN|${level}|${msg}")
+    GITHUB_LINES+=("::warning file=${file}::${msg}")
+    GITLAB_LINES+=("WARNING: [Level ${level}] ${msg}${file:+ (${file})}")
+    if [[ -z "$NEXT_STEP" ]]; then
+        NEXT_STEP="$msg"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Level 1 checks — Basic
+# ---------------------------------------------------------------------------
+check_agents_md_exists() {
+    if [[ -f "AGENTS.md" ]]; then
+        pass 1 "AGENTS.md exists"
+    else
+        fail 1 "AGENTS.md missing at repo root"
+    fi
+}
+
+check_agents_md_length() {
+    if [[ ! -f "AGENTS.md" ]]; then
+        fail 1 "AGENTS.md length check skipped (file missing)"
+        return
+    fi
+    local lines
+    lines=$(wc -l < "AGENTS.md")
+    if (( lines < 150 )); then
+        pass 1 "AGENTS.md is index-format (${lines} lines)"
+    else
+        fail 1 "AGENTS.md is ${lines} lines (should be under 150)"
+    fi
+}
+
+check_agents_md_commands() {
+    if [[ ! -f "AGENTS.md" ]]; then
+        fail 1 "Commands section check skipped (AGENTS.md missing)"
+        return
+    fi
+    if grep -qi '^## *\(available \)\?commands' "AGENTS.md"; then
+        pass 1 "Commands section found"
+    else
+        fail 1 "AGENTS.md missing ## Commands section"
+    fi
+}
+
+check_docs_exists() {
+    if [[ -d "docs" ]]; then
+        pass 1 "docs/ directory exists"
+    else
+        fail 1 "docs/ directory missing" ""
+    fi
+}
+
+run_level1() {
+    check_agents_md_exists
+    check_agents_md_length
+    check_agents_md_commands
+    check_docs_exists
+}
+
+# ---------------------------------------------------------------------------
+# Level 2 checks — Verified
+# ---------------------------------------------------------------------------
+
+# Check that all local file references in AGENTS.md resolve
+check_refs() {
+    if [[ ! -f "AGENTS.md" ]]; then
+        fail 2 "Reference check skipped (AGENTS.md missing)"
+        return
+    fi
+    local has_broken=false
+    # Extract markdown links: [text](path) — skip http(s):// and #anchors
+    while IFS= read -r ref; do
+        # Strip anchor (#...) and query string (?...)
+        local clean
+        clean="${ref%%#*}"
+        clean="${clean%%\?*}"
+        # Skip empty after stripping
+        [[ -z "$clean" ]] && continue
+        # Skip URLs
+        [[ "$clean" =~ ^https?:// ]] && continue
+        # Check if file/dir exists
+        if [[ ! -e "$clean" ]]; then
+            warn 2 "Broken reference in AGENTS.md: ${ref} -> ${clean} not found"
+            has_broken=true
+        fi
+    done < <(grep -oP '\]\(\K[^)]+' "AGENTS.md" 2>/dev/null || true)
+
+    if [[ "$has_broken" == false ]]; then
+        pass 2 "All references resolve"
+    fi
+}
+
+# Check that documented commands have matching targets/scripts
+check_commands() {
+    if [[ ! -f "AGENTS.md" ]]; then
+        fail 2 "Command check skipped (AGENTS.md missing)"
+        return
+    fi
+
+    local found_any=false
+
+    # -- Makefile targets --
+    if [[ -f "Makefile" ]]; then
+        found_any=true
+        local has_make_issue=false
+        while IFS= read -r target; do
+            # Check if Makefile defines this target (pattern: "target:" at start of line)
+            if ! grep -qE "^${target}[[:space:]]*:" "Makefile"; then
+                warn 2 "make ${target}: no matching Makefile target (warning)"
+                has_make_issue=true
+            fi
+        done < <(grep -oP '`make\s+\K[a-zA-Z0-9_-]+' "AGENTS.md" 2>/dev/null || true)
+        if [[ "$has_make_issue" == false ]]; then
+            local make_count
+            make_count=$(grep -oP '`make\s+\K[a-zA-Z0-9_-]+' "AGENTS.md" 2>/dev/null | wc -l || true)
+            if [[ "$make_count" -gt 0 ]]; then
+                pass 2 "All make targets verified (${make_count} targets)"
+            fi
+        fi
+    fi
+
+    # -- composer.json scripts --
+    if [[ -f "composer.json" ]]; then
+        found_any=true
+        local has_composer_issue=false
+        # Built-in composer commands that are NOT user-defined scripts
+        local composer_builtins="install|update|require|remove|dump-autoload|dumpautoload|clear-cache|clearcache|config|create-project|exec|global|init|outdated|prohibits|why|why-not|search|self-update|selfupdate|show|status|validate|archive|browse|check-platform-reqs|diagnose|fund|licenses|run-script|suggests|upgrade"
+        while IFS= read -r script; do
+            # Skip built-in composer commands
+            if echo "$script" | grep -qE "^(${composer_builtins})$"; then
+                continue
+            fi
+            # Look for the script name in composer.json's scripts section
+            # Using grep since jq is optional
+            if ! grep -qE "\"${script}\"" "composer.json"; then
+                warn 2 "composer ${script}: no matching composer.json script (warning)"
+                has_composer_issue=true
+            fi
+        done < <(grep -oP '`composer\s+\K[a-zA-Z0-9:_-]+' "AGENTS.md" 2>/dev/null || true)
+        if [[ "$has_composer_issue" == false ]]; then
+            local composer_count
+            composer_count=$(grep -oP '`composer\s+\K[a-zA-Z0-9:_-]+' "AGENTS.md" 2>/dev/null | wc -l || true)
+            if [[ "$composer_count" -gt 0 ]]; then
+                pass 2 "All composer scripts verified (${composer_count} scripts)"
+            fi
+        fi
+    fi
+
+    # -- package.json scripts --
+    if [[ -f "package.json" ]]; then
+        found_any=true
+        local has_npm_issue=false
+        while IFS= read -r script; do
+            if ! grep -qE "\"${script}\"" "package.json"; then
+                warn 2 "npm run ${script}: no matching package.json script (warning)"
+                has_npm_issue=true
+            fi
+        done < <(grep -oP '`npm run\s+\K[a-zA-Z0-9:_-]+' "AGENTS.md" 2>/dev/null || true)
+        if [[ "$has_npm_issue" == false ]]; then
+            local npm_count
+            npm_count=$(grep -oP '`npm run\s+\K[a-zA-Z0-9:_-]+' "AGENTS.md" 2>/dev/null | wc -l || true)
+            if [[ "$npm_count" -gt 0 ]]; then
+                pass 2 "All npm scripts verified (${npm_count} scripts)"
+            fi
+        fi
+    fi
+
+    if [[ "$found_any" == false ]]; then
+        pass 2 "No build system files found to check commands against"
+    fi
+}
+
+check_architecture_doc() {
+    if [[ -f "docs/ARCHITECTURE.md" ]]; then
+        pass 2 "docs/ARCHITECTURE.md exists"
+    else
+        fail 2 "docs/ARCHITECTURE.md missing" ""
+    fi
+}
+
+check_ci_workflow() {
+    if [[ "$PLATFORM" == "gitlab" ]]; then
+        if [[ -f ".gitlab-ci.yml" ]]; then
+            # Search root file and all include:local files for harness job
+            local found_harness=false
+            if grep -qE "harness-verify|verify-harness" ".gitlab-ci.yml"; then
+                found_harness=true
+            else
+                # Check files referenced via include:local (supports globs).
+                # Portable parser using sed/awk — handles common GitLab CI forms:
+                #   include: { local: 'path' }
+                #   include:
+                #     - local: 'path'
+                #   include:
+                #     - local:
+                #         - path1
+                #         - path2
+                # Skips PCRE (-P) and lookaround for BSD/macOS grep portability.
+                while IFS= read -r inc_pattern; do
+                    [[ -z "$inc_pattern" ]] && continue
+                    # shellcheck disable=SC2086
+                    for inc_file in $inc_pattern; do
+                        if [[ -f "$inc_file" ]] && grep -qE "harness-verify|verify-harness" "$inc_file"; then
+                            found_harness=true
+                            break 2
+                        fi
+                    done
+                done < <(awk '
+                    /^[[:space:]]*-?[[:space:]]*local:[[:space:]]*\[/ {
+                        # inline list form: local: [a.yml, b.yml]
+                        s=$0; sub(/.*local:[[:space:]]*\[/,"",s); sub(/\].*/,"",s);
+                        n=split(s, a, /[[:space:]]*,[[:space:]]*/);
+                        for (i=1;i<=n;i++) print a[i]; next
+                    }
+                    /^[[:space:]]*-?[[:space:]]*local:[[:space:]]*[^[:space:]\[]/ {
+                        # scalar form: local: path or - local: path
+                        s=$0; sub(/.*local:[[:space:]]*/,"",s); print s; next
+                    }
+                ' ".gitlab-ci.yml" 2>/dev/null | tr -d "'\"" || true)
+            fi
+            if [[ "$found_harness" == true ]]; then
+                pass 2 "CI harness job found in GitLab CI config"
+            else
+                warn 2 "CI config exists (.gitlab-ci.yml) but no harness-verify job found"
+            fi
+        else
+            fail 2 "CI harness workflow missing -- create .gitlab-ci.yml with a harness-verify job" ""
+        fi
+    elif [[ "$PLATFORM" == "forgejo" ]]; then
+        if [[ -f ".forgejo/workflows/harness-verify.yml" || -f ".gitea/workflows/harness-verify.yml" ]]; then
+            pass 2 "CI harness workflow exists"
+        else
+            fail 2 "CI harness workflow missing -- create .forgejo/workflows/harness-verify.yml" ""
+        fi
+    else
+        if [[ -f ".github/workflows/harness-verify.yml" ]]; then
+            pass 2 "CI harness workflow exists"
+        else
+            fail 2 "CI harness workflow missing -- create .github/workflows/harness-verify.yml" ""
+        fi
+    fi
+}
+
+run_level2() {
+    check_refs
+    check_commands
+    check_architecture_doc
+    check_ci_workflow
+}
+
+# ---------------------------------------------------------------------------
+# Level 3 checks — Enforced
+# ---------------------------------------------------------------------------
+
+check_hooks_autosetup() {
+    local found=false
+    local via=""
+
+    # Check .envrc for hooksPath
+    if [[ -f ".envrc" ]] && grep -q "hooksPath" ".envrc"; then
+        found=true
+        via=".envrc"
+    fi
+
+    # Check for Husky
+    if [[ -d ".husky" ]]; then
+        found=true
+        via=".husky"
+    fi
+
+    # Check composer.json for post-install-cmd with hooks
+    if [[ -f "composer.json" ]] && grep -q "post-install-cmd" "composer.json"; then
+        if grep -q "hook" "composer.json"; then
+            found=true
+            via="composer.json post-install-cmd"
+        fi
+    fi
+
+    if [[ "$found" == true ]]; then
+        pass 3 "Git hooks auto-setup via ${via}"
+    else
+        warn 3 "No git hooks auto-setup detected (.envrc hooksPath, .husky/, or composer.json post-install-cmd)"
+    fi
+}
+
+check_pr_template() {
+    if [[ "$PLATFORM" == "forgejo" ]]; then
+        # Forgejo/Gitea honour PR templates under .forgejo/, .gitea/ or .github/
+        local f
+        for f in .forgejo/pull_request_template.md .gitea/pull_request_template.md \
+                 .forgejo/PULL_REQUEST_TEMPLATE.md .gitea/PULL_REQUEST_TEMPLATE.md \
+                 .github/pull_request_template.md; do
+            if [[ -f "$f" ]]; then
+                pass 3 "PR template exists ($f)"
+                return
+            fi
+        done
+        warn 3 "PR template missing (create .forgejo/pull_request_template.md)"
+        return
+    fi
+    if [[ "$PLATFORM" == "gitlab" ]]; then
+        if [[ -d ".gitlab/merge_request_templates" ]]; then
+            local tmpl_count
+            tmpl_count=$(find .gitlab/merge_request_templates -maxdepth 1 -type f -name '*.md' 2>/dev/null | wc -l)
+            if (( tmpl_count > 0 )); then
+                pass 3 "MR template exists (.gitlab/merge_request_templates/, ${tmpl_count} template(s))"
+                return
+            fi
+        fi
+        warn 3 "MR template missing (create .gitlab/merge_request_templates/Default.md)"
+    else
+        if [[ -f ".github/pull_request_template.md" ]]; then
+            pass 3 "PR template exists (repo-level)"
+            return
+        fi
+        if [[ -d ".github/PULL_REQUEST_TEMPLATE" ]]; then
+            pass 3 "PR template exists (directory form)"
+            return
+        fi
+        local org=""
+        org=$(git remote get-url origin 2>/dev/null | sed -n 's|.*github\.com[:/]\([^/]*\)/.*|\1|p')
+        if [[ -n "$org" ]]; then
+            local api_result=""
+            api_result=$(gh api "repos/${org}/.github/contents/pull_request_template.md" --jq '.name' 2>/dev/null || true)
+            if [[ "$api_result" == "pull_request_template.md" ]]; then
+                pass 3 "PR template exists (org-level via ${org}/.github)"
+                return
+            fi
+        fi
+        warn 3 "PR template missing (.github/pull_request_template.md or org-level)"
+    fi
+}
+
+check_drift() {
+    # Skip if git is not available
+    if ! command -v git &>/dev/null; then
+        pass 3 "Drift check skipped (git not available)"
+        return
+    fi
+
+    # Skip if not in a git repo
+    if ! git rev-parse --git-dir &>/dev/null 2>&1; then
+        pass 3 "Drift check skipped (not a git repository)"
+        return
+    fi
+
+    # Skip if no parent commit (initial commit)
+    if ! git rev-parse HEAD~1 &>/dev/null 2>&1; then
+        pass 3 "Drift check skipped (no parent commit)"
+        return
+    fi
+
+    # Check if build/CI files changed in last commit
+    local build_files_changed=false
+    local agents_changed=false
+
+    while IFS= read -r changed_file; do
+        case "$changed_file" in
+            Makefile|composer.json|package.json|.github/workflows/*|.gitlab-ci.yml|.forgejo/workflows/*|.gitea/workflows/*)
+                build_files_changed=true
+                ;;
+            AGENTS.md)
+                agents_changed=true
+                ;;
+        esac
+    done < <(git diff --name-only HEAD~1 HEAD 2>/dev/null || true)
+
+    if [[ "$build_files_changed" == true && "$agents_changed" == false ]]; then
+        warn 3 "Potential drift: build/CI files changed in last commit but AGENTS.md was not updated"
+    else
+        pass 3 "No drift detected"
+    fi
+}
+
+run_level3() {
+    check_hooks_autosetup
+    check_pr_template
+    check_drift
+}
+
+# ---------------------------------------------------------------------------
+# Output rendering
+# ---------------------------------------------------------------------------
+
+render_text() {
+    echo "Agent Harness Verification"
+    echo "=========================="
+    echo ""
+
+    local current_level=0
+    local level_names=( [1]="Basic" [2]="Verified" [3]="Enforced" )
+
+    for line in "${OUTPUT_LINES[@]}"; do
+        local kind level msg
+        kind="${line%%|*}"
+        local rest="${line#*|}"
+        level="${rest%%|*}"
+        msg="${rest#*|}"
+        kind="${kind#"${kind%%[![:space:]]*}"}" # trim leading whitespace
+
+        # Print level header when level changes
+        if (( level != current_level )); then
+            if (( current_level != 0 )); then
+                echo ""
+            fi
+            echo "Level ${level} -- ${level_names[$level]}"
+            current_level=$level
+        fi
+
+        case "$kind" in
+            PASS) echo "  ✓ ${msg}" ;;
+            FAIL) echo "  ✗ ${msg}" ;;
+            WARN) echo "  ! ${msg}" ;;
+        esac
+    done
+
+    echo ""
+
+    # Summary line
+    local maturity_level=0
+    for lvl in 1 2 3; do
+        if (( ${LEVEL_TOTAL[$lvl]} > 0 && ${LEVEL_PASS[$lvl]} == ${LEVEL_TOTAL[$lvl]} )); then
+            maturity_level=$lvl
+        else
+            break
+        fi
+    done
+
+    local status="COMPLETE"
+    if (( maturity_level == 0 )); then
+        if (( LEVEL_TOTAL[1] > 0 && LEVEL_PASS[1] > 0 )); then
+            status="PARTIAL"
+        else
+            status="NONE"
+        fi
+        maturity_level=1
+    elif (( maturity_level < 3 )); then
+        # Check if next level is partially done
+        local next_lvl=$(( maturity_level + 1 ))
+        if (( ${LEVEL_TOTAL[$next_lvl]} > 0 && ${LEVEL_PASS[$next_lvl]} < ${LEVEL_TOTAL[$next_lvl]} )); then
+            status="PARTIAL"
+        fi
+    fi
+
+    echo "Summary: Level ${maturity_level} ${status} | ${ERRORS} error(s), ${WARNINGS} warning(s)"
+}
+
+render_github() {
+    if (( ${#GITHUB_LINES[@]} > 0 )); then
+        for line in "${GITHUB_LINES[@]}"; do
+            echo "$line"
+        done
+    fi
+}
+
+render_gitlab() {
+    local ts
+    ts=$(date +%s)
+    echo -e "\e[0Ksection_start:${ts}:harness_verify[collapsed=false]\r\e[0KAgent Harness Verification"
+    if (( ${#GITLAB_LINES[@]} > 0 )); then
+        for line in "${GITLAB_LINES[@]}"; do
+            echo "$line"
+        done
+    fi
+    echo ""
+    echo "Summary: ${ERRORS} error(s), ${WARNINGS} warning(s)"
+    echo -e "\e[0Ksection_end:${ts}:harness_verify\r\e[0K"
+}
+
+render_status() {
+    # Determine highest fully-passing level
+    local maturity_level=0
+    local level_names=( [1]="Basic" [2]="Verified" [3]="Enforced" )
+
+    for lvl in 1 2 3; do
+        if (( ${LEVEL_TOTAL[$lvl]} > 0 && ${LEVEL_PASS[$lvl]} == ${LEVEL_TOTAL[$lvl]} )); then
+            maturity_level=$lvl
+        else
+            break
+        fi
+    done
+
+    local status
+    if (( maturity_level == 0 )); then
+        if (( LEVEL_TOTAL[1] > 0 && LEVEL_PASS[1] > 0 )); then
+            status="PARTIAL"
+        else
+            status="NONE"
+        fi
+        # Display as Level 1 when no level is fully complete
+        local display_level=1
+        echo "Harness Maturity: Level ${display_level} (${level_names[$display_level]}) -- ${status}"
+    else
+        echo "Harness Maturity: Level ${maturity_level} (${level_names[$maturity_level]}) -- COMPLETE"
+    fi
+
+    for lvl in 1 2 3; do
+        if (( ${LEVEL_TOTAL[$lvl]} > 0 )); then
+            echo "  Level ${lvl}: ${LEVEL_PASS[$lvl]}/${LEVEL_TOTAL[$lvl]} checks pass"
+        fi
+    done
+
+    if [[ -n "$NEXT_STEP" ]]; then
+        echo "Next step: ${NEXT_STEP}"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+main() {
+    # Parse arguments
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --format=*)
+                FORMAT="${1#--format=}"
+                ;;
+            --platform=*)
+                PLATFORM="${1#--platform=}"
+                if [[ ! "$PLATFORM" =~ ^(github|gitlab|forgejo)$ ]]; then
+                    echo "Error: --platform must be 'github', 'gitlab' or 'forgejo'" >&2
+                    exit 1
+                fi
+                ;;
+            --level=*)
+                MAX_LEVEL="${1#--level=}"
+                if [[ ! "$MAX_LEVEL" =~ ^[123]$ ]]; then
+                    echo "Error: --level must be 1, 2, or 3" >&2
+                    exit 1
+                fi
+                ;;
+            --check=*)
+                SINGLE_CHECK="${1#--check=}"
+                ;;
+            --status)
+                STATUS_ONLY=true
+                ;;
+            --help|-h)
+                usage
+                ;;
+            *)
+                echo "Unknown option: $1" >&2
+                echo "Run with --help for usage info" >&2
+                exit 1
+                ;;
+        esac
+        shift
+    done
+
+    detect_format
+    detect_platform
+
+    # Run single check category if requested
+    if [[ -n "$SINGLE_CHECK" ]]; then
+        case "$SINGLE_CHECK" in
+            refs)       check_refs ;;
+            commands)   check_commands ;;
+            drift)      check_drift ;;
+            structure)
+                check_agents_md_exists
+                check_docs_exists
+                check_architecture_doc
+                check_ci_workflow
+                check_pr_template
+                ;;
+            *)
+                echo "Unknown check: ${SINGLE_CHECK}" >&2
+                echo "Valid checks: refs, commands, drift, structure" >&2
+                exit 1
+                ;;
+        esac
+    else
+        # Run all checks up to MAX_LEVEL
+        if (( MAX_LEVEL >= 1 )); then
+            run_level1
+        fi
+        if (( MAX_LEVEL >= 2 )); then
+            run_level2
+        fi
+        if (( MAX_LEVEL >= 3 )); then
+            run_level3
+        fi
+    fi
+
+    # Render output
+    if [[ "$STATUS_ONLY" == true ]]; then
+        render_status
+    elif [[ "$FORMAT" == "github" ]]; then
+        render_github
+    elif [[ "$FORMAT" == "gitlab" ]]; then
+        render_gitlab
+    else
+        render_text
+    fi
+
+    # Exit code
+    if (( ERRORS > 0 )); then
+        exit 1
+    elif (( WARNINGS > 0 )); then
+        exit 2
+    else
+        exit 0
+    fi
+}
+
+main "$@"

--- a/Classes/AGENTS.md
+++ b/Classes/AGENTS.md
@@ -1,74 +1,83 @@
-<!-- Managed by agent: keep sections & order; edit content, not structure. Last updated: 2026-01-28 -->
+<!-- Managed by agent: keep sections & order; edit content, not structure. Last updated: 2026-08-19 -->
 
 # AGENTS.md — Classes/
 
-PHP source code for the Contexts Device Detection extension.
+PHP source code for the Contexts Device Detection extension. Namespace `Netresearch\ContextsDevice` (PSR-4, mapped in `composer.json`).
 
 ## Overview
 
 ```
 Classes/
 ├── Context/           # Device detection context types
-│   ├── Type/          # DeviceContext implementation
+│   ├── Type/          # DeviceContext, BrowserContext
 │   └── DeviceDetectionAwareTrait.php  # Request/device-info resolution shared by all context types
-├── Dto/               # Data Transfer Objects
-└── Service/           # Device detection services
+├── Dto/               # DeviceInfo (readonly value object)
+└── Service/           # DeviceDetectionService (matomo/device-detector wrapper)
 ```
+
+## Setup
+
+```bash
+composer install     # installs into .Build/ (composer bin-dir: .Build/bin)
+```
+
+Services are wired in `../Configuration/Services.yaml` (autowire + autoconfigure, `Netresearch\ContextsDevice\` → `../Classes/`).
+
+## Build & Tests
+
+```bash
+composer ci:test:php:unit      # unit tests for this code
+composer ci:test:php:phpstan   # PHPStan (Build/phpstan.neon)
+composer ci:test:php:cgl       # code style check (fix: composer ci:cgl)
+```
+
+Architecture rules for these classes are enforced by PHPat (`Tests/Architecture/LayerTest.php`): context types extend `AbstractContext`, DTOs are readonly, services are final.
 
 ## Code Style & Conventions
 
-### Device Detection Context
+- Context types live in `Context/Type/`, extend `Netresearch\Contexts\Context\AbstractContext` and implement `match(array $arDependencies = []): bool`.
+- Shared request/device-info resolution belongs in `DeviceDetectionAwareTrait`, not duplicated per context type.
+- Service classes are `final`; DTOs are `readonly` with promoted constructor properties.
+- `declare(strict_types=1);` and the SPDX/license header block in every file.
+
+## Security
+
+- Treat the User-Agent header (and client hints) as untrusted input — it is attacker-controlled. Never echo it unescaped or use it in queries/paths.
+- Device detection must fail closed: on parse errors a context should not match rather than throw into the frontend rendering.
+- No secrets, tokens, or credentials in PHP sources.
+
+## Examples
 
 ```php
-namespace Netresearch\ContextsDevice\Context\Type;
-
-use Netresearch\Contexts\Context\AbstractContext;
-use Netresearch\ContextsDevice\Service\DeviceDetectionService;
-
-final class DeviceContext extends AbstractContext
-{
-    public function match(array $arDependencies = []): bool
-    {
-        // Match by device type, OS, browser
-    }
-}
-```
-
-### Device Detection Service
-
-```php
-namespace Netresearch\ContextsDevice\Service;
-
-final class DeviceDetectionService
-{
-    // Uses matomo/device-detector for user agent parsing
-}
-```
-
-### DTOs
-
-```php
-namespace Netresearch\ContextsDevice\Dto;
-
-readonly class DeviceInfo
+// Good: readonly DTO with promoted properties (see Dto/DeviceInfo.php)
+final readonly class DeviceInfo
 {
     public function __construct(
-        public string $type,
-        public ?string $brand,
-        public ?string $model,
+        public bool $isMobile = false,
+        public bool $isTablet = false,
+        // ...
     ) {}
 }
+
+// Bad: parsing the user agent inside a context type — use DeviceDetectionService
+// via DeviceDetectionAwareTrait instead of instantiating DeviceDetector directly.
 ```
 
 ## PR/Commit Checklist
 
-- [ ] New classes follow PSR-4 autoloading
-- [ ] DTOs are readonly
-- [ ] Services are final
-- [ ] Context types extend AbstractContext
+- [ ] New classes follow PSR-4 autoloading (`Netresearch\ContextsDevice\` → `Classes/`)
+- [ ] DTOs are readonly, services are final (PHPat enforces this)
+- [ ] Context types extend `AbstractContext`
+- [ ] Unit tests added/updated for changed behavior
+
+## When Stuck
+
+- Base context API: `.Build/vendor/netresearch/contexts/Classes/Context/AbstractContext.php` (after `composer install`)
+- DeviceDetector API: https://github.com/matomo-org/device-detector
+- Architecture decisions: `../docs/adr/`, component map: `../docs/ARCHITECTURE.md`
+- Open a GitHub issue: https://github.com/netresearch/t3x-contexts_wurfl/issues
 
 ## House Rules
 
-- Device detection via matomo/device-detector library
-- Cache device detection results for performance
-- DTOs must be immutable (readonly)
+- Device detection via matomo/device-detector library only — no WURFL remnants
+- Cache device detection results per request; DTOs must be immutable (readonly)

--- a/Classes/CLAUDE.md
+++ b/Classes/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/Configuration/AGENTS.md
+++ b/Configuration/AGENTS.md
@@ -1,4 +1,4 @@
-<!-- Managed by agent: keep sections & order; edit content, not structure. Last updated: 2026-01-28 -->
+<!-- Managed by agent: keep sections & order; edit content, not structure. Last updated: 2026-08-19 -->
 
 # AGENTS.md — Configuration/
 
@@ -8,48 +8,64 @@ TYPO3 configuration files for the Contexts Device Detection extension.
 
 ```
 Configuration/
-├── TCA/                  # Table Configuration Array
-│   └── Overrides/        # TCA overrides for context registration
-├── FlexForms/            # Dynamic form configurations
-│   └── ContextType/      # Device context configuration forms
-├── Services.yaml         # Symfony DI configuration
-└── Icons.php             # Icon registry
+├── TCA/Overrides/
+│   └── tx_contexts_contexts.php   # Registers Device/Browser context types
+├── FlexForms/
+│   ├── Device.xml                 # Device context configuration form
+│   └── Browser.xml                # Browser context configuration form
+├── Services.yaml                  # Symfony DI (autowire; DeviceDetectionService is public)
+└── Icons.php                      # Icon registry
+```
+
+## Setup
+
+No build step — TYPO3 reads these files directly. After changing `Services.yaml`, flush the DI cache (`ddev exec vendor/bin/typo3 cache:flush` in a DDEV instance, or reinstall via `ddev install-all`).
+
+## Build & Tests
+
+```bash
+composer ci:test:php:functional   # functional tests cover TCA registration + context matching
+composer ci:test:php:cgl          # style check also covers PHP files here
 ```
 
 ## Code Style & Conventions
 
-### Registering Device Context Types
+- Context types are registered in `TCA/Overrides/tx_contexts_contexts.php` via `Netresearch\Contexts\Api\Configuration::registerContextType()` with an `LLL:EXT:contexts_wurfl/...` label and a `FILE:EXT:...` FlexForm reference.
+- FlexForm option values (e.g. device types `mobile`, `tablet`, `desktop`) must match what `DeviceInfo`/the context types evaluate.
+- `DeviceDetectionService` must stay `public: true` in `Services.yaml` — context types are built via `GeneralUtility::makeInstance()` by the base extension and resolve it from the container themselves (see the comment in `Services.yaml`).
+
+## Security
+
+- FlexForm values are user-supplied backend input; context types must validate/whitelist them, never eval or interpolate them into SQL.
+- Keep `public: false` as the service default; expose only what `makeInstance` consumers need.
+- No credentials or environment-specific values in configuration files.
+
+## Examples
 
 ```php
-// TCA/Overrides/tx_contexts_contexts.php
-$GLOBALS['TCA']['tx_contexts_contexts']['columns']['type']['config']['items'][] = [
-    'label' => 'LLL:EXT:contexts_wurfl/Resources/Private/Language/locallang_db.xlf:...',
-    'value' => \Netresearch\ContextsDevice\Context\Type\DeviceContext::class,
-];
-```
+// Good: TCA/Overrides/tx_contexts_contexts.php — register via the base extension API
+Configuration::registerContextType(
+    'device',
+    'LLL:EXT:contexts_wurfl/Resources/Private/Language/locallang.xlf:context.device.title',
+    DeviceContext::class,
+    'FILE:EXT:contexts_wurfl/Configuration/FlexForms/Device.xml',
+);
 
-### FlexForm for Device Selection
-
-```xml
-<field_device_type>
-    <label>Device Type</label>
-    <config>
-        <type>select</type>
-        <renderType>selectCheckBox</renderType>
-        <items>
-            <item><label>Mobile</label><value>mobile</value></item>
-            <item><label>Tablet</label><value>tablet</value></item>
-            <item><label>Desktop</label><value>desktop</value></item>
-        </items>
-    </config>
-</field_device_type>
+// Bad: appending to $GLOBALS['TCA'] directly, hardcoded English labels,
+// or registering a context type without a FlexForm.
 ```
 
 ## PR/Commit Checklist
 
 - [ ] Device context types registered in TCA/Overrides
 - [ ] FlexForms have language file references
-- [ ] Services.yaml changes tested
+- [ ] `Services.yaml` changes covered by functional tests
+
+## When Stuck
+
+- Base extension registration pattern: `.Build/vendor/netresearch/contexts/Configuration/` (after `composer install`)
+- TYPO3 FlexForm reference: https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/ApiOverview/FlexForms/Index.html
+- Open a GitHub issue: https://github.com/netresearch/t3x-contexts_wurfl/issues
 
 ## House Rules
 

--- a/Configuration/CLAUDE.md
+++ b/Configuration/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/Documentation/AGENTS.md
+++ b/Documentation/AGENTS.md
@@ -1,4 +1,4 @@
-<!-- Managed by agent: keep sections & order; edit content, not structure. Last updated: 2026-01-28 -->
+<!-- Managed by agent: keep sections & order; edit content, not structure. Last updated: 2026-08-19 -->
 
 # AGENTS.md — Documentation/
 
@@ -9,13 +9,19 @@ RST documentation for docs.typo3.org publication.
 ```
 Documentation/
 ├── Index.rst              # Main entry point
+├── Sitemap.rst            # Sitemap
 ├── guides.xml             # PHP-based rendering config
+├── Includes.rst.txt       # Shared includes
 ├── Introduction/          # Overview, device detection features
 ├── Installation/          # Setup instructions
 ├── Configuration/         # Device matching options
 ├── Migration/             # Upgrade from WURFL to device-detector
 └── ContextTypes/          # Device context reference
 ```
+
+## Setup
+
+Rendering needs only Docker — no local toolchain. `CLAUDE.md` in this directory is a regular file (not a symlink): the docs renderer's file layer rejects symlinks inside `Documentation/`.
 
 ## Build & Tests
 
@@ -26,9 +32,20 @@ docker run --rm \
     ghcr.io/typo3-documentation/render-guides:latest
 ```
 
+Publication to docs.typo3.org happens via `release.yml`/`republish.yml` (target `docs`).
+
 ## Code Style & Conventions
 
-### Device Detection Documentation
+- Use `.. confval::` for configuration options and `.. versionchanged::`/`.. versionadded::` for behavior changes (e.g. the 2.0.0 WURFL → device-detector switch).
+- Heading underline characters follow the TYPO3 docs convention; keep `Includes.rst.txt` at the top of each file.
+- Reference PHP symbols with their full namespace `Netresearch\ContextsDevice\...`.
+
+## Security
+
+- Never document real credentials; DDEV demo credentials (`admin`/`joh316`) are the only permitted example login.
+- Do not embed third-party tracking or external scripts in doc pages.
+
+## Examples
 
 ```rst
 .. confval:: deviceType
@@ -37,30 +54,26 @@ docker run --rm \
 
    Device types to match: mobile, tablet, desktop, bot.
 
-.. confval:: operatingSystem
-   :type: array
-   :Default: []
-
-   Operating systems to match: iOS, Android, Windows.
-```
-
-### Migration Notes
-
-Document the transition from WURFL to Matomo device-detector:
-
-```rst
 .. versionchanged:: 2.0.0
    Replaced WURFL with matomo/device-detector for license compliance.
 ```
 
 ## PR/Commit Checklist
 
-- [ ] RST renders without warnings
+- [ ] RST renders without warnings (Docker render above)
 - [ ] Device detection options documented
-- [ ] Migration guide complete for WURFL users
+- [ ] Migration guide covers behavior changes for WURFL users
+- [ ] README.md kept in sync with docs
+
+## When Stuck
+
+- TYPO3 docs authoring guide: https://docs.typo3.org/m/typo3/docs-how-to-document/main/en-us/
+- RST directive reference: https://docs.typo3.org/m/typo3/docs-how-to-document/main/en-us/WritingReST/Index.html
+- Rendering config lives in `guides.xml`
+- Open a GitHub issue: https://github.com/netresearch/t3x-contexts_wurfl/issues
 
 ## House Rules
 
-- Output directory: `Documentation-GENERATED-temp/`
+- Output directory: `Documentation-GENERATED-temp/` (git-ignored, never commit)
 - Keep README.md synchronized with docs
 - Document all supported device/OS/browser types

--- a/Documentation/CLAUDE.md
+++ b/Documentation/CLAUDE.md
@@ -1,0 +1,3 @@
+<!-- Regular file, not a symlink: the TYPO3 docs renderer (Flysystem) rejects symbolic links inside Documentation/. -->
+
+@AGENTS.md

--- a/Tests/AGENTS.md
+++ b/Tests/AGENTS.md
@@ -1,4 +1,4 @@
-<!-- Managed by agent: keep sections & order; edit content, not structure. Last updated: 2026-01-28 -->
+<!-- Managed by agent: keep sections & order; edit content, not structure. Last updated: 2026-08-19 -->
 
 # AGENTS.md — Tests/
 
@@ -8,46 +8,63 @@ Test suite for the Contexts Device Detection extension.
 
 ```
 Tests/
-├── Unit/           # Fast, isolated unit tests
-└── Architecture/   # PHPat architecture tests
+├── Unit/           # Fast, isolated unit tests (no DB, no TYPO3 bootstrap)
+├── Functional/     # typo3/testing-framework functional tests (DB, Fixtures/)
+└── Architecture/   # PHPat architecture tests (LayerTest)
+```
+
+## Setup
+
+```bash
+composer install                  # unit tests run out of the box
+# functional tests need a database; in CI the reusable workflow provides MySQL 8.4
 ```
 
 ## Build & Tests
 
 ```bash
-# Run all tests
-composer ci:test:php:unit
-
-# Coverage (requires PCOV or Xdebug)
-composer test:coverage
-
-# Mutation testing
-composer test:mutation
+composer ci:test:php:unit        # unit tests (Build/phpunit/UnitTests.xml)
+composer ci:test:php:functional  # functional tests (Build/phpunit/FunctionalTests.xml, needs DB)
+composer test:coverage           # coverage (requires Xdebug)
+composer test:mutation           # Infection mutation testing
 ```
 
 ## Code Style & Conventions
 
-### Test Class Naming
+- Test namespace mirrors the source: `Netresearch\ContextsDevice\Tests\{Unit,Functional,Architecture}\...`, class name `<Subject>Test`.
+- Mock the user agent via `$_SERVER['HTTP_USER_AGENT']` (or a PSR-7 request attribute) — never depend on the real environment.
+- Functional fixtures live in `Functional/Fixtures/` (CSV, e.g. `tx_contexts_contexts.csv`).
+- Architecture rules in `Architecture/LayerTest.php`: context types extend `AbstractContext`, DTOs readonly, services final.
+
+## Security
+
+- Include hostile user-agent fixtures (oversized strings, control characters) — the UA header is attacker-controlled input.
+- Never commit real visitor data or PII as fixtures; use synthetic user agents.
+- Expected error paths are asserted, not suppressed — test output stays clean.
+
+## Examples
 
 ```php
-Tests\Unit\Context\Type\DeviceContextTest
-Tests\Unit\Service\DeviceDetectionServiceTest
-Tests\Architecture\LayerTest
-```
-
-### User Agent Mocking
-
-```php
-// Mock user agent for device detection tests
+// Good: deterministic UA fixture per test
 $_SERVER['HTTP_USER_AGENT'] = 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X)...';
+
+// Bad: asserting on the machine's own user agent, or sharing one service
+// instance across tests (its per-UA cache bleeds state between tests).
 ```
 
 ## PR/Commit Checklist
 
 - [ ] New functionality has corresponding tests
-- [ ] All tests pass: `composer ci:test:php:unit`
+- [ ] All tests pass: `composer ci:test:php:unit` (+ functional if touched)
 - [ ] Architecture tests pass with PHPat
 - [ ] User agent fixtures cover major device types
+
+## When Stuck
+
+- typo3/testing-framework docs: https://github.com/TYPO3/testing-framework
+- PHPat selectors/rules: https://github.com/carlosas/phpat
+- CI matrix definition: `.github/workflows/ci.yml` (PHP 8.3–8.5 × TYPO3 ^12.4/^13.4)
+- Open a GitHub issue: https://github.com/netresearch/t3x-contexts_wurfl/issues
 
 ## House Rules
 

--- a/Tests/CLAUDE.md
+++ b/Tests/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/composer.json
+++ b/composer.json
@@ -77,6 +77,9 @@
         }
     },
     "scripts": {
+        "post-install-cmd": [
+            "[ -d .git ] && git config core.hooksPath .githooks || true"
+        ],
         "ci:cgl": ".Build/bin/php-cs-fixer fix",
         "ci:rector": ".Build/bin/rector process --config Build/rector.php",
         "ci:test:php:cgl": ".Build/bin/php-cs-fixer fix --dry-run --diff",

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,40 @@
+# Architecture
+
+Agent-facing component map for `netresearch/contexts-wurfl`. Facts here are verified against the source files listed; when code and this document disagree, the code wins — fix this file in the same PR.
+
+## System Overview
+
+The extension adds two context types to the [netresearch/contexts](https://github.com/netresearch/t3x-contexts) base extension: `device` and `browser`. Editors configure them in the TYPO3 backend via FlexForms; at frontend request time the base extension evaluates every configured context, and these types answer their `match()` by parsing the visitor's User-Agent with `matomo/device-detector`.
+
+## Components
+
+| Component | Path | Responsibility |
+|-----------|------|----------------|
+| DeviceContext | `Classes/Context/Type/DeviceContext.php` | Matches configured device types (mobile, tablet, desktop, bot, …) |
+| BrowserContext | `Classes/Context/Type/BrowserContext.php` | Matches configured browser names |
+| DeviceDetectionAwareTrait | `Classes/Context/DeviceDetectionAwareTrait.php` | Shared request access (`$GLOBALS['TYPO3_REQUEST']`) and lazy service resolution for context types built via `GeneralUtility::makeInstance()` |
+| DeviceDetectionService | `Classes/Service/DeviceDetectionService.php` | Wraps `DeviceDetector\DeviceDetector`; `detectForCurrentRequest()` / `detectFromRequest()` / `detectFromUserAgent()`; per-user-agent in-memory cache |
+| DeviceInfo | `Classes/Dto/DeviceInfo.php` | `final readonly` DTO carrying detection results (isMobile, isTablet, …) |
+| Context registration | `Configuration/TCA/Overrides/tx_contexts_contexts.php` | Registers both types via `Netresearch\Contexts\Api\Configuration::registerContextType()` |
+| FlexForms | `Configuration/FlexForms/Device.xml`, `Configuration/FlexForms/Browser.xml` | Backend configuration forms per context type |
+| DI configuration | `Configuration/Services.yaml` | Autowired namespace; `DeviceDetectionService` is `public: true` (resolved from the container by makeInstance-built context types); `DeviceDetector` is `shared: false` |
+
+## Dependency Rules
+
+Enforced by PHPat in `Tests/Architecture/LayerTest.php` (runs with the unit test suite):
+
+1. Classes in `Netresearch\ContextsDevice\Context\Type` must extend `Netresearch\Contexts\Context\AbstractContext`.
+2. Classes in `Netresearch\ContextsDevice\Dto` must be readonly.
+3. Classes in `Netresearch\ContextsDevice\Service` must be final.
+
+## Data Flow
+
+1. Frontend request → base extension `netresearch/contexts` evaluates configured context records and instantiates the registered type class (`Factory::createFromDb()` via `GeneralUtility::makeInstance()`).
+2. `DeviceContext`/`BrowserContext::match()` uses `DeviceDetectionAwareTrait::getDeviceInfo()`: it reads `$GLOBALS['TYPO3_REQUEST']` and calls `DeviceDetectionService::detectFromRequest()`.
+3. The service parses the `User-Agent` header with Matomo DeviceDetector (regex-based, no database), caches the result per user agent string, and returns a `DeviceInfo` DTO — or `null` when no request/user agent is available (contexts then do not match).
+4. The context compares the DTO against the FlexForm-configured values and returns the boolean match to the base extension.
+
+## Key Decisions
+
+- [ADR-0001](adr/0001-replace-wurfl-with-device-detector.md) — replace WURFL with Matomo DeviceDetector (rationale, options considered, capability trade-offs).
+- Migration consequences for users are documented in `Documentation/Migration/Index.rst`.

--- a/docs/exec-plans/README.md
+++ b/docs/exec-plans/README.md
@@ -1,0 +1,8 @@
+# Execution Plans
+
+Working documents for multi-step changes (upgrades, refactorings, feature arcs) that span more than one PR.
+
+- `active/` — plans currently being executed; each plan lists its remaining steps so any agent or human can resume it.
+- `completed/` — finished plans, kept for the decision trail.
+
+Create a plan as a Markdown file with: goal, constraints, ordered steps with completion state, and links to the issues/PRs that implement each step. Update the plan in the same PR that completes a step. Point-in-time architecture facts belong in `../ARCHITECTURE.md`, decisions in `../adr/` — plans only reference them.


### PR DESCRIPTION
Closes #54.

## Explain the details

The AGENTS.md set predated the v2.0.0 DeviceDetector rewrite and described a repository that no longer exists. The root file (234 lines) framed the repo as a LEGACY TYPO3 4.5-6.2 extension with the rewrite only planned, documented phantom CI workflows (phpstan.yml, phpcs.yml, security.yml, publish-to-ter.yml), claimed GrumPHP pre-commit checks that the repo has never had, pinned `netresearch/contexts` at ^2.0 against composer.json's ^3.1.1 || ^4.0, used wrong DDEV hostnames, and indexed only 1 of 4 scoped AGENTS.md files, without links. Scoped files carried their own drift: `Configuration/AGENTS.md` showed direct `$GLOBALS['TCA']` registration while the code uses `Configuration::registerContextType()`, `Classes/AGENTS.md` showed a string-based `DeviceInfo` DTO instead of the actual bool-flag one, `Tests/AGENTS.md` omitted `Tests/Functional/`.

This PR rewrites the root AGENTS.md against verified sources (composer.json scripts, Makefile targets, workflow files, ext_emconf.php, class declarations) at 108 lines with a `## Commands` section and a linked scope index; adds the required Setup/Build-Tests/Security/Examples/When-stuck sections with repo-specific content to all four scoped files; adds CLAUDE.md companions (symlinks, except `Documentation/CLAUDE.md` as a regular `@AGENTS.md` import file because the TYPO3 docs renderer rejects symlinks); and adopts agent-harness Level 2/3: `docs/ARCHITECTURE.md` (component map, PHPat rules quoted 1:1 from `Tests/Architecture/LayerTest.php`, data flow), `docs/exec-plans/`, `Build/Scripts/verify-harness.sh` with a thin `.github/workflows/harness-verify.yml` caller of the shared script-check reusable, and git hooks auto-setup (`.githooks/pre-commit` registered via composer `post-install-cmd`, guarded with `[ -d .git ]` so CI and packaged installs are unaffected).

## Test plan

- `validate-structure.sh`: 8 errors / 1 warning -> 0 / 0
- `verify-content.sh`: 0 warnings (before and after)
- `score-agents.sh`: average 76/100 (root 61) -> average 98/100 (root 90)
- `verify-harness.sh`: Level 1 PARTIAL, 4 errors / 2 warnings -> Level 3 COMPLETE, 0 / 0
- Every path referenced from the AGENTS.md files verified to exist; all markdown fences balanced
- CI on this PR exercises the new harness-verify workflow itself