### PR TITLE
ci: sync harden-runner pin to v2.21.1 from the org template

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -149,7 +149,7 @@ jobs:
     permissions: {}
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        uses: step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1 # v2.21.1
         with:
           egress-policy: audit
 


### PR DESCRIPTION
`drift-scan` reports this repo against the `typo3-extension` template as netresearch/.github#405. The template pins `step-security/harden-runner` at `e14015d5` (v2.21.1); `.github/workflows/checks.yml` here still pins `05e31511` (v2.21.0), and that one line is the entire drift.

Neither Dependabot nor Renovate has an open PR for this repo's GitHub Actions, so the bump is applied by hand rather than by rebasing a bot PR.

After the change the file is byte-identical to the template-synced copy in `netresearch/t3x-nr-xliff-streaming`, verified with `diff`. The drift issue closes itself on the next scan once this lands on `main`.

Signed-off-by: Sebastian Mendel <info@sebastianmendel.de>

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_01Gcm3GRuYBxJGtyj7qviJF8)_
